### PR TITLE
Prevent contact links from wrapping on narrow screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -125,8 +125,8 @@
 <section class="section card">
   <div class="container">
     <h2>Contact Me</h2>
-    <p>Email: <a href="mailto:tmsteph1290@gmail.com">tmsteph1290@gmail.com</a></p>
-    <p>WhatsApp: <a href="https://wa.me/18643602659">864-360-2659</a></p>
+    <p>Email: <a class="contact-link" href="mailto:tmsteph1290@gmail.com">tmsteph1290@gmail.com</a></p>
+    <p>WhatsApp: <a class="contact-link" href="https://wa.me/18643602659">864-360-2659</a></p>
   </div>
 </section>
 

--- a/style.css
+++ b/style.css
@@ -249,6 +249,15 @@ footer {
     word-break: break-word;
   }
 
+  .section.card p a.contact-link {
+    font-size: clamp(0.85rem, 3.8vw, 1.2rem);
+    word-break: normal;
+    white-space: nowrap;
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
   /* Adjust hero padding for small screens */
   .hero {
     padding: 6rem 1rem 3.5rem 1rem;


### PR DESCRIPTION
## Summary
- add a dedicated class to the email and WhatsApp links in the contact section
- adjust mobile styles so the contact links stay on one line by clamping the font size and adding an ellipsis fallback

## Testing
- no automated tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d5516ade188320b04eff713be0e3d9