### PR TITLE
Add command central quick links section

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,6 +89,24 @@
   </div>
 </header>
 
+<!-- Command Central -->
+<section class="section card">
+  <div class="container">
+    <h2>Command Central</h2>
+    <p>Your launchpad for daily tools and creative spaces.</p>
+    <div class="quick-links">
+      <a class="quick-link" href="https://www.youtube.com/" target="_blank" rel="noopener">YouTube</a>
+      <a class="quick-link" href="https://chat.com" target="_blank" rel="noopener">Chat.com</a>
+      <a class="quick-link" href="https://chat.com/codex" target="_blank" rel="noopener">Chat.com Codex</a>
+      <a class="quick-link" href="https://www.google.com/" target="_blank" rel="noopener">Google</a>
+      <a class="quick-link" href="https://mail.google.com/" target="_blank" rel="noopener">Gmail</a>
+      <a class="quick-link" href="https://calendar.google.com/" target="_blank" rel="noopener">Google Calendar</a>
+      <a class="quick-link" href="https://drive.google.com/" target="_blank" rel="noopener">Google Drive</a>
+      <a class="quick-link" href="https://news.ycombinator.com/" target="_blank" rel="noopener">Hacker News</a>
+    </div>
+  </div>
+</section>
+
 <!-- Welcome -->
 <section class="section card fade-in">
   <div class="container">

--- a/style.css
+++ b/style.css
@@ -211,6 +211,38 @@ footer {
 }
 
 /* ===========================
+   COMMAND CENTRAL LINKS
+=========================== */
+.quick-links {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+  gap: 1.25rem;
+  margin-top: 2rem;
+}
+
+.quick-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.9rem 1.1rem;
+  border-radius: 12px;
+  background: rgba(127, 255, 225, 0.12);
+  color: #ffe066;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  text-decoration: none;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  transition: transform 0.3s ease, background 0.3s ease, border 0.3s ease;
+  min-height: 58px;
+}
+
+.quick-link:hover {
+  background: rgba(127, 255, 225, 0.25);
+  border-color: rgba(127, 255, 225, 0.5);
+  transform: translateY(-4px);
+}
+
+/* ===========================
    FOOTER
 =========================== */
 footer {
@@ -271,6 +303,16 @@ footer {
     max-width: none;
     margin-inline: auto;
     flex: 0 0 var(--project-card-width);
+  }
+
+  .quick-links {
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 1rem;
+  }
+
+  .quick-link {
+    padding: 0.85rem 1rem;
+    min-height: 52px;
   }
 
   /* Ensure text stays centered */


### PR DESCRIPTION
## Summary
- add a Command Central section to the home page with direct links to frequently used destinations
- style the new quick link tiles to match the existing card layout and remain responsive on mobile

## Testing
- not run (static site change)


------
https://chatgpt.com/codex/tasks/task_e_68d831a287748320a023be0cec1610ee