### PR TITLE
Fix starfield overflow causing horizontal space

### DIFF
--- a/style.css
+++ b/style.css
@@ -66,6 +66,7 @@ p {
 =========================== */
 #starfield {
   position: absolute;
+  inset: 0;
   width: 100%;
   height: 100%;
   background: transparent;


### PR DESCRIPTION
## Summary
- anchor the starfield layer to its container edges so it no longer extends past the viewport
- retain the existing animation and background layering while preventing horizontal overflow

## Testing
- python playwright script to confirm `document.documentElement.scrollWidth` now matches `window.innerWidth`


------
https://chatgpt.com/codex/tasks/task_e_68d8bf68f5648320b770c321a5c37610