### PR TITLE
Improve admin offline handling and add homepage login button

### DIFF
--- a/admin/style.css
+++ b/admin/style.css
@@ -90,6 +90,10 @@ textarea {
   color: #9cffb0;
 }
 
+.form-message[data-state="warning"] {
+  color: #ffd27f;
+}
+
 .panel-header {
   display: flex;
   justify-content: space-between;

--- a/index.html
+++ b/index.html
@@ -86,6 +86,7 @@
     <p class="tagline">Dream. Build. Share.</p>
     <a href="https://tommyos.vercel.app" class="btn-primary">Explore TommyOS</a>
     <a href="https://3dvr.tech" class="btn-secondary">Visit 3dvr.tech</a>
+    <a href="admin/index.html" class="btn-secondary">Log In</a>
   </div>
 </header>
 


### PR DESCRIPTION
## Summary
- add additional peer fallbacks and connection status messaging to the admin control center to clarify login issues when sync relays are offline
- surface offline save notices for status and note updates so data persistence expectations are clear
- add a login button on the homepage hero for quick access to the admin area

## Testing
- Manual verification in local browser

------
https://chatgpt.com/codex/tasks/task_e_68dad2304e908320a73b08491a8e4ac0