### PR TITLE
Prevent initial PWA reload on first visit

### DIFF
--- a/pwa.js
+++ b/pwa.js
@@ -4,6 +4,7 @@
   }
 
   let refreshing = false;
+  let hasActiveServiceWorker = navigator.serviceWorker.controller !== null;
 
   window.addEventListener('load', () => {
     const manifestLink = document.querySelector('link[rel="manifest"]');
@@ -35,9 +36,15 @@
   });
 
   navigator.serviceWorker.addEventListener('controllerchange', () => {
+    if (!hasActiveServiceWorker) {
+      hasActiveServiceWorker = true;
+      return;
+    }
+
     if (refreshing) {
       return;
     }
+
     refreshing = true;
     window.location.reload();
   });


### PR DESCRIPTION
## Summary
- avoid reloading the page the first time the service worker takes control

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68db7899ae648320adf0a0a936f2e399