### PR TITLE
[codex] add Calm Structure app

### DIFF
--- a/assets/css/calm-shared.css
+++ b/assets/css/calm-shared.css
@@ -1,0 +1,115 @@
+:root {
+  color-scheme: light;
+  --calm-bg: #f4f1ea;
+  --calm-surface: #fffdf8;
+  --calm-surface-2: #ebe7dc;
+  --calm-ink: #252820;
+  --calm-muted: #62685b;
+  --calm-line: #d6d0c2;
+  --calm-sage: #6f8e78;
+  --calm-blue: #426b83;
+  --calm-clay: #a55f46;
+  --calm-gold: #c79035;
+  --calm-danger: #8b2f2f;
+  --calm-radius: 8px;
+  --calm-shadow: 0 16px 36px rgba(40, 43, 36, 0.12);
+  --calm-font: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --calm-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--calm-bg);
+  color: var(--calm-ink);
+  font-family: var(--calm-font);
+}
+
+button,
+input,
+select,
+textarea {
+  font: inherit;
+}
+
+button,
+.calm-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 40px;
+  border: 1px solid var(--calm-line);
+  border-radius: var(--calm-radius);
+  padding: 0.55rem 0.85rem;
+  background: var(--calm-surface);
+  color: var(--calm-ink);
+  font-weight: 750;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+button:hover,
+button:focus-visible,
+.calm-button:hover,
+.calm-button:focus-visible {
+  border-color: var(--calm-sage);
+  outline: 2px solid rgba(111, 142, 120, 0.22);
+  outline-offset: 2px;
+}
+
+button.primary,
+.calm-button.primary {
+  border-color: var(--calm-sage);
+  background: var(--calm-sage);
+  color: #fffdf8;
+}
+
+button.danger,
+.calm-button.danger {
+  border-color: rgba(139, 47, 47, 0.34);
+  color: var(--calm-danger);
+}
+
+button.ghost,
+.calm-button.ghost {
+  background: transparent;
+}
+
+input,
+select,
+textarea {
+  width: 100%;
+  border: 1px solid var(--calm-line);
+  border-radius: var(--calm-radius);
+  background: #fffefb;
+  color: var(--calm-ink);
+  padding: 0.72rem 0.78rem;
+}
+
+textarea {
+  resize: vertical;
+}
+
+label {
+  display: grid;
+  gap: 0.35rem;
+  color: var(--calm-muted);
+  font-size: 0.9rem;
+  font-weight: 700;
+}
+
+.calm-sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/assets/js/calm-crypto.js
+++ b/assets/js/calm-crypto.js
@@ -1,0 +1,17 @@
+export const CALM_CRYPTO_STATUS = 'local-only-phase';
+
+export function describeCryptoPlan() {
+  return {
+    current: 'Phase one stores only this-browser demo data in localStorage.',
+    next: 'Shared household records should be encrypted with a household key before Gun writes.',
+    safety: 'Safety notes remain local-only by default and should not be synced automatically.'
+  };
+}
+
+export async function encryptSharedRecord() {
+  throw new Error('Shared encryption is intentionally not enabled in the local-only MVP.');
+}
+
+export async function decryptSharedRecord() {
+  throw new Error('Shared encryption is intentionally not enabled in the local-only MVP.');
+}

--- a/assets/js/calm-models.js
+++ b/assets/js/calm-models.js
@@ -1,0 +1,195 @@
+import { addDaysISO, todayISO } from './calm-utils.js';
+
+export const TASK_DOMAINS = [
+  'meals',
+  'groceries',
+  'dishes',
+  'laundry',
+  'trash',
+  'child',
+  'bedtime',
+  'appointments',
+  'bills',
+  'cleaning',
+  'repair',
+  'health',
+  'work'
+];
+
+export const MOOD_STATES = [
+  'regulated',
+  'tired',
+  'overloaded',
+  'needs space',
+  'needs help',
+  'needs listening',
+  'needs plan',
+  'repair needed'
+];
+
+export const REQUEST_TYPES = [
+  'listen',
+  'help',
+  'space',
+  'plan',
+  'reassurance'
+];
+
+export const MEAL_SLOTS = ['breakfast', 'lunch', 'dinner', 'snack'];
+
+export const RESET_ITEMS = [
+  { id: 'kitchen', label: 'Kitchen reset' },
+  { id: 'trash', label: 'Trash checked' },
+  { id: 'laundry', label: 'Laundry noticed' },
+  { id: 'child-supplies', label: 'Child supplies ready' },
+  { id: 'tomorrow-meal', label: "Tomorrow's meal checked" }
+];
+
+export function createInitialState(now = new Date()) {
+  const selectedDate = todayISO(now);
+  return {
+    version: 1,
+    selectedDate,
+    settings: {
+      householdName: 'Home',
+      selfName: 'Me',
+      demoMode: true
+    },
+    tasks: [
+      {
+        id: 'task_seed_dinners',
+        title: 'Pick three simple dinners',
+        domain: 'meals',
+        owner: 'Me',
+        status: 'open',
+        dueDate: selectedDate,
+        recurrence: 'weekly',
+        visiblePromise: 'I will choose three dinners and generate the grocery list.',
+        notes: '',
+        createdAt: now.getTime(),
+        updatedAt: now.getTime()
+      },
+      {
+        id: 'task_seed_reset',
+        title: 'Do a 15-minute kitchen reset',
+        domain: 'cleaning',
+        owner: 'Me',
+        status: 'open',
+        dueDate: selectedDate,
+        recurrence: 'daily',
+        visiblePromise: 'I will make the kitchen easier to walk into tonight.',
+        notes: '',
+        createdAt: now.getTime(),
+        updatedAt: now.getTime()
+      }
+    ],
+    mealPlan: [],
+    checkIns: [],
+    supportMaps: [],
+    repairs: [
+      {
+        id: 'repair_seed_next_step',
+        eventLabel: 'Choose one repair',
+        whatIOwn: 'I can make one small concrete action visible today.',
+        impact: '',
+        repairAction: 'Name the next honest step and do it before the day gets crowded.',
+        nextAction: 'Pick one thing from the Owned by Me board.',
+        status: 'open',
+        createdAt: now.getTime(),
+        updatedAt: now.getTime()
+      }
+    ],
+    shoppingItems: [],
+    handledLogs: [],
+    resetChecks: {}
+  };
+}
+
+export function migrateState(rawState, now = new Date()) {
+  const seed = createInitialState(now);
+  if (!rawState || typeof rawState !== 'object') {
+    return seed;
+  }
+
+  return {
+    ...seed,
+    ...rawState,
+    settings: {
+      ...seed.settings,
+      ...(rawState.settings || {})
+    },
+    tasks: Array.isArray(rawState.tasks) ? rawState.tasks : seed.tasks,
+    mealPlan: Array.isArray(rawState.mealPlan) ? rawState.mealPlan : [],
+    checkIns: Array.isArray(rawState.checkIns) ? rawState.checkIns : [],
+    supportMaps: Array.isArray(rawState.supportMaps) ? rawState.supportMaps : [],
+    repairs: Array.isArray(rawState.repairs) ? rawState.repairs : seed.repairs,
+    shoppingItems: Array.isArray(rawState.shoppingItems) ? rawState.shoppingItems : [],
+    handledLogs: Array.isArray(rawState.handledLogs) ? rawState.handledLogs : [],
+    resetChecks: rawState.resetChecks && typeof rawState.resetChecks === 'object' ? rawState.resetChecks : {}
+  };
+}
+
+export function getWeekDates(anchorDate = todayISO()) {
+  const anchor = new Date(`${anchorDate}T00:00:00`);
+  const day = Number.isNaN(anchor.getTime()) ? 0 : anchor.getDay();
+  const sunday = addDaysISO(anchorDate, -day);
+  return Array.from({ length: 7 }, (_value, index) => addDaysISO(sunday, index));
+}
+
+export function getTodayTasks(tasks = [], selectedDate = todayISO()) {
+  return tasks.filter((task) => {
+    if (task.deletedAt || task.status === 'done') return false;
+    if (!task.dueDate) return true;
+    return task.dueDate <= selectedDate;
+  });
+}
+
+export function getOpenRepair(repairs = []) {
+  return repairs.find((repair) => !repair.deletedAt && repair.status !== 'complete') || null;
+}
+
+export function getLatestCheckIn(checkIns = []) {
+  return [...checkIns]
+    .filter((entry) => !entry.deletedAt)
+    .sort((a, b) => (b.createdAt || 0) - (a.createdAt || 0))[0] || null;
+}
+
+export function getMealsForDate(mealPlan = [], selectedDate = todayISO()) {
+  return mealPlan
+    .filter((entry) => !entry.deletedAt && entry.date === selectedDate)
+    .sort((a, b) => MEAL_SLOTS.indexOf(a.mealSlot) - MEAL_SLOTS.indexOf(b.mealSlot));
+}
+
+export function generateShoppingItems(mealEntries = [], meals = []) {
+  const mealsById = new Map(meals.map((meal) => [meal.id, meal]));
+  const ingredients = new Map();
+
+  mealEntries.forEach((entry) => {
+    [entry.mealId, entry.fallbackMealId].filter(Boolean).forEach((mealId) => {
+      const meal = mealsById.get(mealId);
+      if (!meal) return;
+      meal.ingredients.forEach((ingredient) => {
+        const key = `${ingredient.name.toLowerCase()}::${ingredient.category || 'Other'}`;
+        if (!ingredients.has(key)) {
+          ingredients.set(key, {
+            name: ingredient.name,
+            category: ingredient.category || 'Other',
+            quantity: '',
+            sourceMeals: [meal.name],
+            purchased: false
+          });
+          return;
+        }
+        const existing = ingredients.get(key);
+        if (!existing.sourceMeals.includes(meal.name)) {
+          existing.sourceMeals.push(meal.name);
+        }
+      });
+    });
+  });
+
+  return Array.from(ingredients.values()).sort((a, b) => {
+    const categoryCompare = a.category.localeCompare(b.category);
+    return categoryCompare || a.name.localeCompare(b.name);
+  });
+}

--- a/assets/js/calm-store.js
+++ b/assets/js/calm-store.js
@@ -1,0 +1,66 @@
+import { createInitialState, migrateState } from './calm-models.js';
+import { createId } from './calm-utils.js';
+
+const STORAGE_KEY = 'tmstephCalmStructure.v1';
+const SAFETY_NOTES_KEY = 'tmstephCalmStructure.safetyNotes.v1';
+
+export function loadState(storage = globalThis.localStorage, now = new Date()) {
+  if (!storage) {
+    return createInitialState(now);
+  }
+
+  try {
+    const stored = storage.getItem(STORAGE_KEY);
+    return migrateState(stored ? JSON.parse(stored) : null, now);
+  } catch (_error) {
+    return createInitialState(now);
+  }
+}
+
+export function saveState(state, storage = globalThis.localStorage) {
+  if (!storage) return;
+  storage.setItem(STORAGE_KEY, JSON.stringify(state));
+}
+
+export function resetState(storage = globalThis.localStorage) {
+  if (!storage) return;
+  storage.removeItem(STORAGE_KEY);
+}
+
+export function loadSafetyNotes(storage = globalThis.localStorage) {
+  if (!storage) return '';
+  try {
+    return storage.getItem(SAFETY_NOTES_KEY) || '';
+  } catch (_error) {
+    return '';
+  }
+}
+
+export function saveSafetyNotes(notes, storage = globalThis.localStorage) {
+  if (!storage) return;
+  storage.setItem(SAFETY_NOTES_KEY, String(notes || ''));
+}
+
+export function clearSafetyNotes(storage = globalThis.localStorage) {
+  if (!storage) return;
+  storage.removeItem(SAFETY_NOTES_KEY);
+}
+
+export function createRecord(type, payload = {}) {
+  const now = Date.now();
+  return {
+    id: payload.id || createId(type),
+    type,
+    ...payload,
+    createdAt: payload.createdAt || now,
+    updatedAt: now
+  };
+}
+
+export function upsertById(records = [], record) {
+  const exists = records.some((item) => item.id === record.id);
+  if (!exists) {
+    return [...records, record];
+  }
+  return records.map((item) => (item.id === record.id ? { ...item, ...record, updatedAt: Date.now() } : item));
+}

--- a/assets/js/calm-utils.js
+++ b/assets/js/calm-utils.js
@@ -1,0 +1,52 @@
+export function todayISO(now = new Date()) {
+  return toISODate(now);
+}
+
+export function toISODate(value) {
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return '';
+  }
+  return date.toISOString().split('T')[0];
+}
+
+export function addDaysISO(dateValue, offset) {
+  const date = new Date(`${dateValue}T00:00:00`);
+  date.setDate(date.getDate() + offset);
+  return toISODate(date);
+}
+
+export function formatDate(value) {
+  if (!value) return '';
+  const parsed = new Date(`${value}T00:00:00`);
+  if (Number.isNaN(parsed.getTime())) return value;
+  return parsed.toLocaleDateString(undefined, {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric'
+  });
+}
+
+export function createId(prefix = 'rec') {
+  const random = Math.random().toString(16).slice(2, 8);
+  return `${prefix}_${Date.now().toString(36)}_${random}`;
+}
+
+export function normalizeText(value) {
+  return String(value || '').trim();
+}
+
+export function sortByUpdatedDesc(records = []) {
+  return [...records].sort((a, b) => (b.updatedAt || b.createdAt || 0) - (a.updatedAt || a.createdAt || 0));
+}
+
+export function groupBy(records = [], getKey) {
+  return records.reduce((groups, record) => {
+    const key = getKey(record);
+    if (!groups[key]) {
+      groups[key] = [];
+    }
+    groups[key].push(record);
+    return groups;
+  }, {});
+}

--- a/assets/js/gun-client.js
+++ b/assets/js/gun-client.js
@@ -1,0 +1,24 @@
+export const GUN_PEERS = ['https://peer.tmsteph.com/gun'];
+
+export function createGunClient({ Gun: GunLib = globalThis.Gun, peers = GUN_PEERS } = {}) {
+  if (!GunLib) {
+    return {
+      gun: null,
+      user: null,
+      available: false,
+      reason: 'Gun is not loaded in this local-only phase.'
+    };
+  }
+
+  const gun = GunLib({
+    peers,
+    localStorage: true
+  });
+
+  return {
+    gun,
+    user: gun.user(),
+    available: true,
+    reason: ''
+  };
+}

--- a/calm-structure/README.md
+++ b/calm-structure/README.md
@@ -1,0 +1,101 @@
+# Calm Structure
+
+Calm Structure is a private household rhythm for meals, proactive ownership, check-ins, repair, and safety.
+
+The principle is:
+
+```txt
+Awareness -> structure -> action -> repair -> trust
+```
+
+This first version is intentionally local-only. It does not connect to GunJS yet and does not sync sensitive household data. The goal is to make the workflow useful before adding authentication, encryption, and shared storage.
+
+## Route
+
+```txt
+/calm-structure/
+```
+
+## Phase One
+
+- Today dashboard
+- Owned tasks
+- Meal rhythm
+- Grocery generation from seed meals
+- Emotional check-ins
+- Trigger/support maps
+- Repair log
+- Safety resources
+- Local-only safety notes
+- Settings for household/self labels
+
+## Safety
+
+This tool is for planning, grounding, and repair. It is not therapy, legal advice, or emergency support. If anyone is in immediate danger, call 911.
+
+Safety notes are saved only in this browser's `localStorage` in phase one. They are not shared, synced, or sent to analytics.
+
+Current resource sources:
+
+- City of San Diego Domestic Violence page: `https://www.sandiego.gov/police/services/domestic-violence`
+- Your Safe Place / San Diego Family Justice Center: `https://www.sandiego.gov/sdfjc`
+- San Diego Regional Domestic Violence Resources Phone Guide: `https://www.sdcourt.ca.gov/sites/default/files/2021-08/San%20Diego%20Regional%20DOMESTIC%20VIOLENCE%20RESOURCES%20Phone%20Guide.pdf`
+
+## Data
+
+Phase one stores non-synced demo data at:
+
+```txt
+localStorage["tmstephCalmStructure.v1"]
+localStorage["tmstephCalmStructure.safetyNotes.v1"]
+```
+
+Seed meal data lives at:
+
+```txt
+/data/seed-meals.json
+```
+
+Safety resource data lives at:
+
+```txt
+/data/safety-resources.json
+```
+
+## Future GunJS/SEA Plan
+
+The shared storage phase should use GunJS plus SEA, but only after encryption is implemented.
+
+Rules for the next phase:
+
+1. Do not write sensitive relationship data to plaintext public Gun paths.
+2. Use SEA auth for identity.
+3. Generate a household key for shared records.
+4. Encrypt every shared task, check-in, support map, repair, and meal note before writing it to Gun.
+5. Keep safety notes local-only by default.
+6. Do not add diagnostics, scoring, surveillance, or blame language.
+
+Suggested paths:
+
+```txt
+tmsteph/calm/v1/households/{householdId}/meta
+tmsteph/calm/v1/households/{householdId}/members/{memberPub}
+tmsteph/calm/v1/households/{householdId}/records/{recordId}
+~{userPub}/calm/v1/profile
+~{userPub}/calm/v1/privateNotes/{noteId}
+```
+
+## Local Development
+
+From the repo root:
+
+```bash
+npm install
+npm run start
+```
+
+Then open:
+
+```txt
+http://localhost:8000/calm-structure/
+```

--- a/calm-structure/app.js
+++ b/calm-structure/app.js
@@ -1,0 +1,511 @@
+import {
+  MEAL_SLOTS,
+  MOOD_STATES,
+  REQUEST_TYPES,
+  RESET_ITEMS,
+  TASK_DOMAINS,
+  generateShoppingItems,
+  getLatestCheckIn,
+  getMealsForDate,
+  getOpenRepair,
+  getTodayTasks,
+  getWeekDates
+} from '../assets/js/calm-models.js';
+import {
+  clearSafetyNotes,
+  createRecord,
+  loadSafetyNotes,
+  loadState,
+  resetState,
+  saveSafetyNotes,
+  saveState,
+  upsertById
+} from '../assets/js/calm-store.js';
+import { addDaysISO, formatDate, todayISO } from '../assets/js/calm-utils.js';
+
+const state = loadState();
+let seedMeals = [];
+let safetyResources = [];
+
+const $ = (selector) => document.querySelector(selector);
+const $$ = (selector) => Array.from(document.querySelectorAll(selector));
+
+function persist() {
+  saveState(state);
+}
+
+function setView(viewName) {
+  $$('.tab').forEach((tab) => tab.classList.toggle('active', tab.dataset.viewTarget === viewName));
+  $$('.view').forEach((view) => view.classList.toggle('active', view.id === `view-${viewName}`));
+}
+
+function optionList(values, selected = '') {
+  return values.map((value) => `<option value="${value}"${value === selected ? ' selected' : ''}>${titleCase(value)}</option>`).join('');
+}
+
+function mealOptions(selected = '', includeEmpty = false) {
+  const empty = includeEmpty ? '<option value="">None</option>' : '';
+  return `${empty}${seedMeals.map((meal) => `<option value="${meal.id}"${meal.id === selected ? ' selected' : ''}>${meal.name}</option>`).join('')}`;
+}
+
+function titleCase(value = '') {
+  return String(value)
+    .split(/[\s-]+/)
+    .filter(Boolean)
+    .map((part) => `${part.charAt(0).toUpperCase()}${part.slice(1)}`)
+    .join(' ');
+}
+
+function mealName(mealId) {
+  return seedMeals.find((meal) => meal.id === mealId)?.name || 'Unplanned';
+}
+
+function renderToday() {
+  $('#selected-date').value = state.selectedDate;
+  $('#meal-date').value = $('#meal-date').value || state.selectedDate;
+  $('#task-due').value = $('#task-due').value || state.selectedDate;
+
+  const todayMeals = getMealsForDate(state.mealPlan, state.selectedDate);
+  $('#today-meals').innerHTML = todayMeals.length
+    ? todayMeals.map((entry) => `
+        <div class="record">
+          <div class="record-header">
+            <span class="record-title">${titleCase(entry.mealSlot)}</span>
+            <span class="tag">${entry.assignedCook || state.settings.selfName}</span>
+          </div>
+          <div>${mealName(entry.mealId)}</div>
+          ${entry.fallbackMealId ? `<div class="record-meta">Fallback: ${mealName(entry.fallbackMealId)}</div>` : ''}
+        </div>
+      `).join('')
+    : '<div class="empty">No meals planned for this date yet.</div>';
+
+  const todayTasks = getTodayTasks(state.tasks, state.selectedDate);
+  $('#today-tasks').innerHTML = todayTasks.length
+    ? todayTasks.slice(0, 5).map(renderTaskRecord).join('')
+    : '<div class="empty">No open owned tasks due today.</div>';
+
+  const dayChecks = state.resetChecks[state.selectedDate] || {};
+  $('#reset-checks').innerHTML = RESET_ITEMS.map((item) => `
+    <label class="check-row">
+      <input type="checkbox" data-reset-id="${item.id}"${dayChecks[item.id] ? ' checked' : ''}>
+      <span>${item.label}</span>
+    </label>
+  `).join('');
+
+  const latestCheckIn = getLatestCheckIn(state.checkIns);
+  $('#latest-checkin').innerHTML = latestCheckIn
+    ? `<strong>${titleCase(latestCheckIn.moodState)}</strong><br>${titleCase(latestCheckIn.requestType)}${latestCheckIn.message ? ` - ${escapeHtml(latestCheckIn.message)}` : ''}`
+    : 'No check-in saved yet.';
+
+  const openRepair = getOpenRepair(state.repairs);
+  $('#open-repair').innerHTML = openRepair
+    ? `<strong>${escapeHtml(openRepair.eventLabel)}</strong><br>${escapeHtml(openRepair.nextAction || openRepair.repairAction)}`
+    : 'No open repair right now.';
+
+  const handled = state.handledLogs
+    .filter((log) => log.date === state.selectedDate)
+    .sort((a, b) => b.createdAt - a.createdAt);
+  $('#handled-list').innerHTML = handled.length
+    ? handled.map((log) => `<div class="handled-item">${escapeHtml(log.text)}</div>`).join('')
+    : '<div class="empty">Nothing logged yet.</div>';
+}
+
+function renderMeals() {
+  const weekDates = getWeekDates(state.selectedDate);
+  const entriesByDate = Object.groupBy
+    ? Object.groupBy(state.mealPlan.filter((entry) => !entry.deletedAt), (entry) => entry.date)
+    : state.mealPlan.reduce((grouped, entry) => {
+        if (!entry.deletedAt) {
+          grouped[entry.date] = [...(grouped[entry.date] || []), entry];
+        }
+        return grouped;
+      }, {});
+
+  $('#week-plan').innerHTML = weekDates.map((date) => {
+    const entries = (entriesByDate[date] || []).sort((a, b) => MEAL_SLOTS.indexOf(a.mealSlot) - MEAL_SLOTS.indexOf(b.mealSlot));
+    const rows = entries.length
+      ? entries.map((entry) => `
+          <div class="meal-row">
+            <span>${titleCase(entry.mealSlot)}</span>
+            <span>${mealName(entry.mealId)}${entry.fallbackMealId ? ` / fallback: ${mealName(entry.fallbackMealId)}` : ''}</span>
+          </div>
+        `).join('')
+      : '<div class="meal-row"><span>Open</span><span>No meals planned.</span></div>';
+    return `<div class="week-day"><strong>${formatDate(date)}</strong>${rows}</div>`;
+  }).join('');
+
+  $('#grocery-list').innerHTML = state.shoppingItems.length
+    ? state.shoppingItems.map((item) => `
+        <div class="grocery-item">
+          <strong>${escapeHtml(item.name)}</strong>
+          <span class="record-meta">${escapeHtml(item.category)} / ${escapeHtml(item.sourceMeals?.join(', ') || 'Meal plan')}</span>
+        </div>
+      `).join('')
+    : '<div class="empty">Generate groceries from this week&apos;s meal plan.</div>';
+}
+
+function renderTasks() {
+  const mode = $('#task-filter').value;
+  const weekEnd = addDaysISO(state.selectedDate, 7);
+  let tasks = state.tasks.filter((task) => !task.deletedAt);
+
+  if (mode === 'today') {
+    tasks = getTodayTasks(tasks, state.selectedDate);
+  } else if (mode === 'week') {
+    tasks = tasks.filter((task) => task.status !== 'done' && (!task.dueDate || task.dueDate <= weekEnd));
+  } else if (mode === 'done') {
+    tasks = tasks.filter((task) => task.status === 'done');
+  } else if (mode === 'recurring') {
+    tasks = tasks.filter((task) => task.recurrence);
+  }
+
+  tasks.sort((a, b) => (a.dueDate || '9999').localeCompare(b.dueDate || '9999'));
+  $('#task-list').innerHTML = tasks.length ? tasks.map(renderTaskRecord).join('') : '<div class="empty">No tasks in this view.</div>';
+}
+
+function renderTaskRecord(task) {
+  return `
+    <div class="record" data-task-id="${task.id}">
+      <div class="record-header">
+        <span class="record-title">${escapeHtml(task.title)}</span>
+        <span class="tag">${escapeHtml(task.status || 'open')}</span>
+      </div>
+      <div class="record-meta">
+        <span>${escapeHtml(task.domain || 'household')}</span>
+        <span>${task.dueDate ? formatDate(task.dueDate) : 'No date'}</span>
+        <span>${escapeHtml(task.owner || state.settings.selfName || 'Me')}</span>
+      </div>
+      ${task.visiblePromise ? `<div>${escapeHtml(task.visiblePromise)}</div>` : ''}
+      <div class="record-actions">
+        <button type="button" data-task-action="claim">Claim ownership</button>
+        <button type="button" class="primary" data-task-action="done">Done visibly</button>
+        ${task.recurrence ? '<button type="button" data-task-action="duplicate">Next recurrence</button>' : ''}
+      </div>
+    </div>
+  `;
+}
+
+function renderCheckIns() {
+  const recent = [...state.checkIns].filter((entry) => !entry.deletedAt).sort((a, b) => b.createdAt - a.createdAt);
+  $('#checkin-list').innerHTML = recent.length
+    ? recent.slice(0, 8).map((entry) => `
+        <div class="record">
+          <div class="record-header">
+            <span class="record-title">${titleCase(entry.moodState)}</span>
+            <span class="tag">${titleCase(entry.requestType)}</span>
+          </div>
+          ${entry.message ? `<div>${escapeHtml(entry.message)}</div>` : ''}
+          <div class="record-meta">${new Date(entry.createdAt).toLocaleString()}</div>
+        </div>
+      `).join('')
+    : '<div class="empty">No check-ins yet.</div>';
+
+  $('#support-map-list').innerHTML = state.supportMaps.length
+    ? state.supportMaps.filter((entry) => !entry.deletedAt).map((entry) => `
+        <div class="record">
+          <strong>${escapeHtml(entry.situation)}</strong>
+          <div><span class="tag">Helps</span> ${escapeHtml(entry.whatHelps)}</div>
+          ${entry.requestPhrase ? `<div><span class="tag">Ask</span> ${escapeHtml(entry.requestPhrase)}</div>` : ''}
+          ${entry.boundary ? `<div><span class="tag">Boundary</span> ${escapeHtml(entry.boundary)}</div>` : ''}
+        </div>
+      `).join('')
+    : '<div class="empty">No support maps saved yet.</div>';
+}
+
+function renderRepairs() {
+  const repairs = state.repairs.filter((repair) => !repair.deletedAt).sort((a, b) => (b.updatedAt || 0) - (a.updatedAt || 0));
+  $('#repair-list').innerHTML = repairs.length
+    ? repairs.map((repair) => `
+        <div class="record" data-repair-id="${repair.id}">
+          <div class="record-header">
+            <span class="record-title">${escapeHtml(repair.eventLabel)}</span>
+            <span class="tag">${escapeHtml(repair.status || 'open')}</span>
+          </div>
+          <div><strong>Mine:</strong> ${escapeHtml(repair.whatIOwn)}</div>
+          <div><strong>Repair:</strong> ${escapeHtml(repair.repairAction)}</div>
+          <div><strong>Next:</strong> ${escapeHtml(repair.nextAction)}</div>
+          <div class="record-actions">
+            <button type="button" class="primary" data-repair-action="complete">Complete repair</button>
+          </div>
+        </div>
+      `).join('')
+    : '<div class="empty">No repairs logged yet.</div>';
+}
+
+function renderSafety() {
+  $('#safety-resources').innerHTML = safetyResources
+    .sort((a, b) => a.priority - b.priority)
+    .map((resource) => `
+      <div class="resource">
+        <strong>${escapeHtml(resource.label)}</strong>
+        <a href="tel:${resource.phone.replace(/[^0-9]/g, '')}">${escapeHtml(resource.phone)}</a>
+        <span>${escapeHtml(resource.description)}</span>
+        <a href="${resource.url}" target="_blank" rel="noreferrer">Source</a>
+      </div>
+    `).join('');
+}
+
+function renderSettings() {
+  $('#self-name').value = state.settings.selfName || 'Me';
+  $('#household-name').value = state.settings.householdName || 'Home';
+}
+
+function renderAll() {
+  renderToday();
+  renderMeals();
+  renderTasks();
+  renderCheckIns();
+  renderRepairs();
+  renderSafety();
+  renderSettings();
+}
+
+function setupStaticOptions() {
+  $('#meal-slot').innerHTML = optionList(MEAL_SLOTS);
+  $('#meal-choice').innerHTML = mealOptions();
+  $('#fallback-meal').innerHTML = mealOptions('', true);
+  $('#task-domain').innerHTML = optionList(TASK_DOMAINS);
+  $('#mood-state').innerHTML = optionList(MOOD_STATES);
+  $('#request-type').innerHTML = optionList(REQUEST_TYPES);
+}
+
+function setupEvents() {
+  document.addEventListener('click', (event) => {
+    const target = event.target.closest('[data-view-target]');
+    if (target) {
+      setView(target.dataset.viewTarget);
+    }
+
+    const taskButton = event.target.closest('[data-task-action]');
+    if (taskButton) {
+      handleTaskAction(taskButton.closest('[data-task-id]')?.dataset.taskId, taskButton.dataset.taskAction);
+    }
+
+    const repairButton = event.target.closest('[data-repair-action]');
+    if (repairButton) {
+      handleRepairAction(repairButton.closest('[data-repair-id]')?.dataset.repairId, repairButton.dataset.repairAction);
+    }
+  });
+
+  $('#selected-date').addEventListener('change', (event) => {
+    state.selectedDate = event.target.value || todayISO();
+    persist();
+    renderAll();
+  });
+
+  $('#reset-checks').addEventListener('change', (event) => {
+    const input = event.target.closest('[data-reset-id]');
+    if (!input) return;
+    state.resetChecks[state.selectedDate] = {
+      ...(state.resetChecks[state.selectedDate] || {}),
+      [input.dataset.resetId]: input.checked
+    };
+    persist();
+  });
+
+  $('#handled-form').addEventListener('submit', (event) => {
+    event.preventDefault();
+    const input = $('#handled-text');
+    const text = input.value.trim();
+    if (!text) return;
+    state.handledLogs.push(createRecord('handled', { text, date: state.selectedDate }));
+    input.value = '';
+    persist();
+    renderToday();
+  });
+
+  $('#meal-form').addEventListener('submit', (event) => {
+    event.preventDefault();
+    const record = createRecord('mealPlanEntry', {
+      date: $('#meal-date').value || state.selectedDate,
+      mealSlot: $('#meal-slot').value,
+      mealId: $('#meal-choice').value,
+      fallbackMealId: $('#fallback-meal').value,
+      assignedCook: $('#assigned-cook').value.trim() || state.settings.selfName,
+      groceryGenerated: false
+    });
+    state.mealPlan = upsertById(state.mealPlan, record);
+    persist();
+    renderAll();
+  });
+
+  $('#generate-groceries').addEventListener('click', () => {
+    const weekDates = new Set(getWeekDates(state.selectedDate));
+    const planned = state.mealPlan.filter((entry) => !entry.deletedAt && weekDates.has(entry.date));
+    state.shoppingItems = generateShoppingItems(planned, seedMeals).map((item) => createRecord('shoppingItem', item));
+    state.mealPlan = state.mealPlan.map((entry) => weekDates.has(entry.date) ? { ...entry, groceryGenerated: true, updatedAt: Date.now() } : entry);
+    persist();
+    renderMeals();
+  });
+
+  $('#task-form').addEventListener('submit', (event) => {
+    event.preventDefault();
+    const record = createRecord('task', {
+      title: $('#task-title').value.trim(),
+      domain: $('#task-domain').value,
+      owner: $('#task-owner').value.trim() || state.settings.selfName,
+      status: 'open',
+      dueDate: $('#task-due').value,
+      recurrence: $('#task-recurrence').value,
+      visiblePromise: $('#task-promise').value.trim(),
+      notes: $('#task-notes').value.trim()
+    });
+    if (!record.title) return;
+    state.tasks.push(record);
+    event.target.reset();
+    $('#task-due').value = state.selectedDate;
+    persist();
+    renderAll();
+  });
+
+  $('#task-filter').addEventListener('change', renderTasks);
+
+  $('#checkin-form').addEventListener('submit', (event) => {
+    event.preventDefault();
+    state.checkIns.push(createRecord('checkIn', {
+      moodState: $('#mood-state').value,
+      requestType: $('#request-type').value,
+      urgency: $('#checkin-urgency').value,
+      visibility: 'local',
+      message: $('#checkin-message').value.trim()
+    }));
+    $('#checkin-message').value = '';
+    persist();
+    renderAll();
+  });
+
+  $('#support-map-form').addEventListener('submit', (event) => {
+    event.preventDefault();
+    const record = createRecord('triggerSupportMap', {
+      situation: $('#support-situation').value.trim(),
+      whatHelps: $('#support-helps').value.trim(),
+      whatMakesItWorse: $('#support-worse').value.trim(),
+      requestPhrase: $('#support-request').value.trim(),
+      boundary: $('#support-boundary').value.trim()
+    });
+    if (!record.situation) return;
+    state.supportMaps.push(record);
+    event.target.reset();
+    persist();
+    renderCheckIns();
+  });
+
+  $('#repair-form').addEventListener('submit', (event) => {
+    event.preventDefault();
+    state.repairs.push(createRecord('repair', {
+      eventLabel: $('#repair-event').value.trim(),
+      whatIOwn: $('#repair-own').value.trim(),
+      impact: $('#repair-impact').value.trim(),
+      repairAction: $('#repair-action').value.trim(),
+      nextAction: $('#repair-next').value.trim(),
+      status: 'open'
+    }));
+    event.target.reset();
+    persist();
+    renderAll();
+  });
+
+  $('#quick-exit').addEventListener('click', () => {
+    window.location.replace('https://www.google.com/search?q=weather');
+  });
+
+  $('#safety-notes').value = loadSafetyNotes();
+  $('#save-safety-notes').addEventListener('click', () => {
+    saveSafetyNotes($('#safety-notes').value);
+  });
+  $('#clear-safety-notes').addEventListener('click', () => {
+    clearSafetyNotes();
+    $('#safety-notes').value = '';
+  });
+
+  $('#settings-form').addEventListener('submit', (event) => {
+    event.preventDefault();
+    state.settings.selfName = $('#self-name').value.trim() || 'Me';
+    state.settings.householdName = $('#household-name').value.trim() || 'Home';
+    persist();
+    renderAll();
+  });
+
+  $('#reset-demo').addEventListener('click', () => {
+    resetState();
+    window.location.reload();
+  });
+}
+
+function handleTaskAction(taskId, action) {
+  const task = state.tasks.find((item) => item.id === taskId);
+  if (!task) return;
+
+  if (action === 'claim') {
+    task.owner = state.settings.selfName || 'Me';
+  }
+
+  if (action === 'done') {
+    task.status = 'done';
+    task.doneAt = Date.now();
+    state.handledLogs.push(createRecord('handled', {
+      text: task.title,
+      date: state.selectedDate
+    }));
+  }
+
+  if (action === 'duplicate') {
+    const nextDue = task.recurrence === 'daily'
+      ? addDaysISO(task.dueDate || state.selectedDate, 1)
+      : task.recurrence === 'monthly'
+        ? addDaysISO(task.dueDate || state.selectedDate, 30)
+        : addDaysISO(task.dueDate || state.selectedDate, 7);
+    state.tasks.push(createRecord('task', {
+      ...task,
+      id: undefined,
+      status: 'open',
+      doneAt: null,
+      dueDate: nextDue
+    }));
+  }
+
+  task.updatedAt = Date.now();
+  persist();
+  renderAll();
+}
+
+function handleRepairAction(repairId, action) {
+  const repair = state.repairs.find((item) => item.id === repairId);
+  if (!repair || action !== 'complete') return;
+  repair.status = 'complete';
+  repair.completedAt = Date.now();
+  repair.updatedAt = Date.now();
+  persist();
+  renderAll();
+}
+
+function escapeHtml(value = '') {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}
+
+async function loadJson(path, fallback = []) {
+  try {
+    const response = await fetch(path);
+    if (!response.ok) return fallback;
+    return await response.json();
+  } catch (_error) {
+    return fallback;
+  }
+}
+
+async function init() {
+  [seedMeals, safetyResources] = await Promise.all([
+    loadJson('../data/seed-meals.json'),
+    loadJson('../data/safety-resources.json')
+  ]);
+  setupStaticOptions();
+  setupEvents();
+  renderAll();
+}
+
+init();

--- a/calm-structure/index.html
+++ b/calm-structure/index.html
@@ -1,0 +1,405 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="Calm Structure is a private household rhythm for meals, proactive tasks, repair, grounding, and safety.">
+  <title>Calm Structure - tmsteph</title>
+  <link rel="stylesheet" href="../assets/css/calm-shared.css">
+  <link rel="stylesheet" href="./styles.css">
+  <link rel="icon" href="../favicon.ico" type="image/x-icon">
+</head>
+<body>
+  <header class="topbar">
+    <a class="brand" href="../index.html" aria-label="Back to tmsteph">
+      <span class="brand-mark" aria-hidden="true">CS</span>
+      <span>
+        <strong>Calm Structure</strong>
+        <small>Awareness / structure / action / repair / trust</small>
+      </span>
+    </a>
+    <div class="topbar-actions">
+      <span class="status-pill" id="storage-status">Local-only MVP</span>
+      <a class="calm-button ghost" href="../index.html">Home</a>
+    </div>
+  </header>
+
+  <main class="app-shell">
+    <section class="intro">
+      <div>
+        <p class="eyebrow">Private household rhythm</p>
+        <h1>Before the day gets loud, handle one real thing.</h1>
+      </div>
+      <div class="intro-panel" aria-label="Daily questions">
+        <span>What needs to be handled before stress builds?</span>
+        <span>What can I take off someone&apos;s plate?</span>
+        <span>What is the next honest step?</span>
+      </div>
+    </section>
+
+    <nav class="tabs" aria-label="Calm Structure sections">
+      <button class="tab active" type="button" data-view-target="today">Today</button>
+      <button class="tab" type="button" data-view-target="meals">Meal Rhythm</button>
+      <button class="tab" type="button" data-view-target="tasks">Owned by Me</button>
+      <button class="tab" type="button" data-view-target="checkin">Check-In</button>
+      <button class="tab" type="button" data-view-target="repair">Repair</button>
+      <button class="tab" type="button" data-view-target="safety">Safety</button>
+      <button class="tab" type="button" data-view-target="settings">Settings</button>
+    </nav>
+
+    <section class="view active" id="view-today" aria-labelledby="today-title">
+      <div class="view-heading">
+        <div>
+          <p class="eyebrow">Today</p>
+          <h2 id="today-title">Today&apos;s Structure</h2>
+        </div>
+        <label class="date-control" for="selected-date">
+          Date
+          <input type="date" id="selected-date">
+        </label>
+      </div>
+
+      <div class="dashboard-grid">
+        <article class="panel span-2">
+          <div class="panel-heading">
+            <h3>Meals</h3>
+            <button type="button" class="ghost" data-view-target="meals">Plan meals</button>
+          </div>
+          <div class="compact-list" id="today-meals"></div>
+        </article>
+
+        <article class="panel">
+          <div class="panel-heading">
+            <h3>Owned by Me</h3>
+            <button type="button" class="ghost" data-view-target="tasks">Add task</button>
+          </div>
+          <div class="compact-list" id="today-tasks"></div>
+        </article>
+
+        <article class="panel">
+          <h3>Household Reset</h3>
+          <div class="check-grid" id="reset-checks"></div>
+        </article>
+
+        <article class="panel">
+          <h3>Latest Check-In</h3>
+          <div id="latest-checkin" class="quiet-block"></div>
+        </article>
+
+        <article class="panel">
+          <h3>One Repair</h3>
+          <div id="open-repair" class="quiet-block"></div>
+        </article>
+
+        <article class="panel span-2">
+          <form id="handled-form" class="inline-form">
+            <label for="handled-text">
+              I handled this
+              <input id="handled-text" name="handled-text" placeholder="Handled item...">
+            </label>
+            <button class="primary" type="submit">Log it</button>
+          </form>
+          <div class="handled-list" id="handled-list"></div>
+        </article>
+      </div>
+    </section>
+
+    <section class="view" id="view-meals" aria-labelledby="meals-title">
+      <div class="view-heading">
+        <div>
+          <p class="eyebrow">Meals</p>
+          <h2 id="meals-title">Meal Rhythm</h2>
+        </div>
+        <button type="button" class="primary" id="generate-groceries">Generate grocery list</button>
+      </div>
+
+      <div class="two-column">
+        <form class="panel form-grid" id="meal-form">
+          <h3>Plan a meal</h3>
+          <label for="meal-date">
+            Date
+            <input type="date" id="meal-date" required>
+          </label>
+          <label for="meal-slot">
+            Slot
+            <select id="meal-slot" required></select>
+          </label>
+          <label for="meal-choice">
+            Meal
+            <select id="meal-choice" required></select>
+          </label>
+          <label for="fallback-meal">
+            Fallback meal
+            <select id="fallback-meal"></select>
+          </label>
+          <label for="assigned-cook">
+            Assigned cook
+            <input id="assigned-cook" placeholder="Me">
+          </label>
+          <button class="primary" type="submit">Save meal</button>
+        </form>
+
+        <article class="panel">
+          <h3>This week</h3>
+          <div class="week-plan" id="week-plan"></div>
+        </article>
+      </div>
+
+      <section class="panel">
+        <div class="panel-heading">
+          <h3>Generated groceries</h3>
+          <a class="calm-button ghost" href="../shopping-list/index.html">Open Shopping List</a>
+        </div>
+        <div class="grocery-grid" id="grocery-list"></div>
+      </section>
+    </section>
+
+    <section class="view" id="view-tasks" aria-labelledby="tasks-title">
+      <div class="view-heading">
+        <div>
+          <p class="eyebrow">Owned by Me</p>
+          <h2 id="tasks-title">Proactive Ownership</h2>
+        </div>
+      </div>
+
+      <div class="two-column">
+        <form class="panel form-grid" id="task-form">
+          <h3>Own a reality</h3>
+          <label for="task-title">
+            Title
+            <input id="task-title" required placeholder="Plan dinners for Monday-Wednesday">
+          </label>
+          <label for="task-domain">
+            Domain
+            <select id="task-domain" required></select>
+          </label>
+          <label for="task-owner">
+            Owner
+            <input id="task-owner" placeholder="Me">
+          </label>
+          <label for="task-due">
+            Due date
+            <input type="date" id="task-due">
+          </label>
+          <label for="task-recurrence">
+            Recurrence
+            <select id="task-recurrence">
+              <option value="">None</option>
+              <option value="daily">Daily</option>
+              <option value="weekly">Weekly</option>
+              <option value="monthly">Monthly</option>
+            </select>
+          </label>
+          <label for="task-promise">
+            Visible promise
+            <textarea id="task-promise" rows="3" placeholder="I will handle this so it does not have to be held alone."></textarea>
+          </label>
+          <label for="task-notes">
+            Notes
+            <textarea id="task-notes" rows="3"></textarea>
+          </label>
+          <button class="primary" type="submit">Add task</button>
+        </form>
+
+        <article class="panel">
+          <div class="panel-heading">
+            <h3>Board</h3>
+            <select id="task-filter" aria-label="Task view">
+              <option value="today">Today</option>
+              <option value="week">This Week</option>
+              <option value="done">Done</option>
+              <option value="recurring">Recurring</option>
+            </select>
+          </div>
+          <div class="record-list" id="task-list"></div>
+        </article>
+      </div>
+    </section>
+
+    <section class="view" id="view-checkin" aria-labelledby="checkin-title">
+      <div class="view-heading">
+        <div>
+          <p class="eyebrow">Check-In</p>
+          <h2 id="checkin-title">Low-conflict check-in</h2>
+        </div>
+      </div>
+
+      <div class="two-column">
+        <form class="panel form-grid" id="checkin-form">
+          <h3>Current state</h3>
+          <label for="mood-state">
+            State
+            <select id="mood-state" required></select>
+          </label>
+          <label for="request-type">
+            Request
+            <select id="request-type" required></select>
+          </label>
+          <label for="checkin-urgency">
+            Urgency
+            <select id="checkin-urgency">
+              <option value="low">Low</option>
+              <option value="medium">Medium</option>
+              <option value="high">High</option>
+            </select>
+          </label>
+          <label for="checkin-message">
+            Message
+            <textarea id="checkin-message" rows="4" placeholder="I need listening, help, space, or a plan."></textarea>
+          </label>
+          <button class="primary" type="submit">Save check-in</button>
+        </form>
+
+        <article class="panel">
+          <h3>Recent check-ins</h3>
+          <div class="record-list" id="checkin-list"></div>
+        </article>
+      </div>
+
+      <div class="two-column">
+        <form class="panel form-grid" id="support-map-form">
+          <h3>Support map</h3>
+          <label for="support-situation">
+            Situation
+            <input id="support-situation" placeholder="When I feel criticized...">
+          </label>
+          <label for="support-helps">
+            What helps
+            <textarea id="support-helps" rows="3"></textarea>
+          </label>
+          <label for="support-worse">
+            What makes it worse
+            <textarea id="support-worse" rows="3"></textarea>
+          </label>
+          <label for="support-request">
+            Request phrase
+            <input id="support-request" placeholder="Can we pause and name the next action?">
+          </label>
+          <label for="support-boundary">
+            Boundary
+            <textarea id="support-boundary" rows="3"></textarea>
+          </label>
+          <button class="primary" type="submit">Save map</button>
+        </form>
+
+        <article class="panel">
+          <h3>Saved support maps</h3>
+          <div class="record-list" id="support-map-list"></div>
+        </article>
+      </div>
+    </section>
+
+    <section class="view" id="view-repair" aria-labelledby="repair-title">
+      <div class="view-heading">
+        <div>
+          <p class="eyebrow">Repair</p>
+          <h2 id="repair-title">Repair Log</h2>
+        </div>
+      </div>
+
+      <div class="two-column">
+        <form class="panel form-grid" id="repair-form">
+          <h3>One concrete repair</h3>
+          <label for="repair-event">
+            Event label
+            <input id="repair-event" placeholder="Dinner plan missed" required>
+          </label>
+          <label for="repair-own">
+            What part is mine?
+            <textarea id="repair-own" rows="3" required></textarea>
+          </label>
+          <label for="repair-impact">
+            Impact
+            <textarea id="repair-impact" rows="3"></textarea>
+          </label>
+          <label for="repair-action">
+            What would rebuild trust?
+            <textarea id="repair-action" rows="3" required></textarea>
+          </label>
+          <label for="repair-next">
+            Next concrete action
+            <input id="repair-next" required>
+          </label>
+          <button class="primary" type="submit">Add repair</button>
+        </form>
+
+        <article class="panel">
+          <h3>Open repairs</h3>
+          <div class="record-list" id="repair-list"></div>
+        </article>
+      </div>
+    </section>
+
+    <section class="view" id="view-safety" aria-labelledby="safety-title">
+      <div class="safety-banner">
+        <div>
+          <p class="eyebrow">Safety</p>
+          <h2 id="safety-title">Planning, grounding, and support.</h2>
+        </div>
+        <button class="danger" type="button" id="quick-exit">Quick exit</button>
+      </div>
+
+      <div class="notice">
+        This tool is for planning, grounding, and repair. It is not therapy, legal advice, or emergency support.
+        If anyone is in immediate danger, call 911.
+      </div>
+
+      <div class="two-column">
+        <article class="panel">
+          <h3>Resources</h3>
+          <div class="resource-list" id="safety-resources"></div>
+        </article>
+
+        <article class="panel">
+          <h3>Local-only safety notes</h3>
+          <label for="safety-notes">
+            Personal notes on this device
+            <textarea id="safety-notes" rows="9" placeholder="Emergency contacts, go-bag location, child-safe exit plan..."></textarea>
+          </label>
+          <div class="button-row">
+            <button type="button" class="primary" id="save-safety-notes">Save locally</button>
+            <button type="button" class="danger" id="clear-safety-notes">Clear notes</button>
+          </div>
+          <p class="microcopy">These notes stay in this browser&apos;s local storage in phase one and are not shown anywhere else.</p>
+        </article>
+      </div>
+    </section>
+
+    <section class="view" id="view-settings" aria-labelledby="settings-title">
+      <div class="view-heading">
+        <div>
+          <p class="eyebrow">Settings</p>
+          <h2 id="settings-title">Local setup</h2>
+        </div>
+      </div>
+
+      <div class="two-column">
+        <form class="panel form-grid" id="settings-form">
+          <h3>Household profile</h3>
+          <label for="self-name">
+            My display name
+            <input id="self-name" placeholder="Me">
+          </label>
+          <label for="household-name">
+            Household name
+            <input id="household-name" placeholder="Home">
+          </label>
+          <button class="primary" type="submit">Save settings</button>
+        </form>
+
+        <article class="panel">
+          <h3>Privacy status</h3>
+          <div class="settings-stack">
+            <p><strong>Current mode:</strong> local-only browser storage.</p>
+            <p><strong>Next phase:</strong> GunJS login plus encrypted household records before sync.</p>
+            <p><strong>Safety notes:</strong> local-only by default.</p>
+          </div>
+          <button class="danger" type="button" id="reset-demo">Reset local demo data</button>
+        </article>
+      </div>
+    </section>
+  </main>
+
+  <script type="module" src="./app.js"></script>
+</body>
+</html>

--- a/calm-structure/styles.css
+++ b/calm-structure/styles.css
@@ -1,0 +1,411 @@
+.topbar {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.8rem clamp(1rem, 3vw, 2rem);
+  border-bottom: 1px solid var(--calm-line);
+  background: rgba(244, 241, 234, 0.92);
+  backdrop-filter: blur(16px);
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  color: var(--calm-ink);
+  text-decoration: none;
+}
+
+.brand small {
+  display: block;
+  color: var(--calm-muted);
+  font-size: 0.78rem;
+}
+
+.brand-mark {
+  display: inline-grid;
+  place-items: center;
+  width: 42px;
+  height: 42px;
+  border-radius: var(--calm-radius);
+  background: var(--calm-ink);
+  color: var(--calm-bg);
+  font-weight: 850;
+}
+
+.topbar-actions,
+.button-row,
+.panel-heading,
+.view-heading {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.topbar-actions,
+.panel-heading,
+.view-heading {
+  justify-content: space-between;
+}
+
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  min-height: 32px;
+  padding: 0 0.7rem;
+  border-radius: 999px;
+  border: 1px solid rgba(111, 142, 120, 0.35);
+  background: #edf4eb;
+  color: #385a42;
+  font-size: 0.82rem;
+  font-weight: 800;
+}
+
+.app-shell {
+  width: min(1220px, calc(100vw - 1.5rem));
+  margin: 0 auto;
+  padding: 1rem 0 4rem;
+}
+
+.intro {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(280px, 0.65fr);
+  gap: 1rem;
+  align-items: end;
+  padding: clamp(1.8rem, 4vw, 3.5rem) 0 1.2rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.6rem;
+  color: var(--calm-blue);
+  font-size: 0.78rem;
+  font-weight: 850;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+h3,
+p {
+  margin-top: 0;
+}
+
+h1,
+h2,
+h3 {
+  line-height: 1.05;
+  letter-spacing: 0;
+}
+
+h1 {
+  max-width: 14ch;
+  margin-bottom: 0;
+  font-size: clamp(2.5rem, 7vw, 5.8rem);
+}
+
+h2 {
+  margin-bottom: 0;
+  font-size: clamp(1.9rem, 4vw, 3.4rem);
+}
+
+h3 {
+  margin-bottom: 0;
+  font-size: 1.1rem;
+}
+
+.intro-panel {
+  display: grid;
+  gap: 0.5rem;
+  border: 1px solid var(--calm-line);
+  border-radius: var(--calm-radius);
+  padding: 1rem;
+  background: var(--calm-surface);
+  color: var(--calm-muted);
+  box-shadow: var(--calm-shadow);
+}
+
+.intro-panel span {
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid var(--calm-line);
+}
+
+.intro-panel span:last-child {
+  padding-bottom: 0;
+  border-bottom: 0;
+}
+
+.tabs {
+  display: flex;
+  gap: 0.5rem;
+  overflow-x: auto;
+  padding: 0.5rem;
+  border: 1px solid var(--calm-line);
+  border-radius: var(--calm-radius);
+  background: var(--calm-surface);
+}
+
+.tab {
+  flex: 0 0 auto;
+  background: transparent;
+  color: var(--calm-muted);
+}
+
+.tab.active {
+  background: var(--calm-ink);
+  color: var(--calm-surface);
+  border-color: var(--calm-ink);
+}
+
+.view {
+  display: none;
+  padding-top: 1rem;
+}
+
+.view.active {
+  display: grid;
+  gap: 1rem;
+}
+
+.view-heading {
+  flex-wrap: wrap;
+  padding: 1rem 0;
+}
+
+.date-control {
+  width: min(100%, 220px);
+}
+
+.dashboard-grid,
+.two-column {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.dashboard-grid {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.span-2 {
+  grid-column: span 2;
+}
+
+.panel {
+  border: 1px solid var(--calm-line);
+  border-radius: var(--calm-radius);
+  background: var(--calm-surface);
+  padding: 1rem;
+  box-shadow: var(--calm-shadow);
+}
+
+.panel-heading {
+  margin-bottom: 0.85rem;
+  flex-wrap: wrap;
+}
+
+.form-grid {
+  display: grid;
+  gap: 0.85rem;
+  align-content: start;
+}
+
+.inline-form {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.75rem;
+  align-items: end;
+}
+
+.compact-list,
+.record-list,
+.resource-list,
+.handled-list,
+.week-plan,
+.grocery-grid,
+.settings-stack {
+  display: grid;
+  gap: 0.65rem;
+}
+
+.empty,
+.quiet-block,
+.record,
+.resource,
+.grocery-item,
+.week-day,
+.handled-item {
+  border: 1px solid var(--calm-line);
+  border-radius: var(--calm-radius);
+  padding: 0.8rem;
+  background: #fbfaf4;
+}
+
+.empty,
+.quiet-block {
+  color: var(--calm-muted);
+}
+
+.record {
+  display: grid;
+  gap: 0.55rem;
+}
+
+.record-header,
+.record-meta,
+.record-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.record-header {
+  justify-content: space-between;
+}
+
+.record-title {
+  font-weight: 850;
+}
+
+.record-meta {
+  color: var(--calm-muted);
+  font-size: 0.86rem;
+}
+
+.tag {
+  display: inline-flex;
+  align-items: center;
+  min-height: 26px;
+  padding: 0 0.48rem;
+  border-radius: 999px;
+  border: 1px solid var(--calm-line);
+  background: var(--calm-surface-2);
+  color: var(--calm-muted);
+  font-size: 0.78rem;
+  font-weight: 800;
+}
+
+.check-grid {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.check-row {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  min-height: 36px;
+}
+
+.check-row input {
+  width: 18px;
+  height: 18px;
+}
+
+.week-day {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.week-day strong {
+  color: var(--calm-blue);
+}
+
+.meal-row {
+  display: grid;
+  grid-template-columns: 86px 1fr;
+  gap: 0.65rem;
+  color: var(--calm-muted);
+  font-size: 0.92rem;
+}
+
+.grocery-grid {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.grocery-item {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.safety-banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  border: 1px solid rgba(139, 47, 47, 0.28);
+  border-radius: var(--calm-radius);
+  padding: 1rem;
+  background: #fff7f1;
+}
+
+.notice {
+  border-left: 4px solid var(--calm-danger);
+  border-radius: var(--calm-radius);
+  padding: 0.9rem 1rem;
+  background: #fffdf8;
+  color: var(--calm-danger);
+  font-weight: 750;
+}
+
+.resource {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.resource a {
+  color: var(--calm-blue);
+  font-weight: 800;
+}
+
+.microcopy {
+  margin: 0.7rem 0 0;
+  color: var(--calm-muted);
+  font-size: 0.88rem;
+}
+
+@media (max-width: 980px) {
+  .intro,
+  .two-column,
+  .dashboard-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .span-2 {
+    grid-column: auto;
+  }
+}
+
+@media (max-width: 620px) {
+  .topbar,
+  .topbar-actions,
+  .safety-banner,
+  .inline-form {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .inline-form {
+    display: grid;
+    grid-template-columns: 1fr;
+  }
+
+  .topbar {
+    position: static;
+  }
+
+  .topbar-actions {
+    width: 100%;
+  }
+
+  .topbar-actions .calm-button,
+  .topbar-actions .status-pill {
+    width: 100%;
+    justify-content: center;
+  }
+}

--- a/data/safety-resources.json
+++ b/data/safety-resources.json
@@ -1,0 +1,34 @@
+[
+  {
+    "id": "emergency",
+    "label": "Emergency",
+    "phone": "911",
+    "description": "Call or text 911 if anyone is in immediate danger or needs urgent medical help.",
+    "url": "https://www.sandiego.gov/police/services/domestic-violence",
+    "priority": 1
+  },
+  {
+    "id": "your-safe-place",
+    "label": "Your Safe Place / San Diego Family Justice Center",
+    "phone": "619-533-6000",
+    "description": "Confidential San Diego services for domestic violence, family violence, sexual assault, trafficking, and gun violence.",
+    "url": "https://www.sandiego.gov/sdfjc",
+    "priority": 2
+  },
+  {
+    "id": "center-community-solutions",
+    "label": "Center for Community Solutions",
+    "phone": "888-385-4657",
+    "description": "San Diego domestic violence and sexual assault crisis support listed in the regional resource guide.",
+    "url": "https://www.sdcourt.ca.gov/sites/default/files/2021-08/San%20Diego%20Regional%20DOMESTIC%20VIOLENCE%20RESOURCES%20Phone%20Guide.pdf",
+    "priority": 3
+  },
+  {
+    "id": "national-dv-hotline",
+    "label": "National Domestic Violence Hotline",
+    "phone": "1-800-799-SAFE",
+    "description": "National confidential hotline: 1-800-799-7233.",
+    "url": "https://www.thehotline.org/",
+    "priority": 4
+  }
+]

--- a/data/seed-meals.json
+++ b/data/seed-meals.json
@@ -1,0 +1,167 @@
+[
+  {
+    "id": "avocado-toast",
+    "name": "Avocado Toast",
+    "slots": ["breakfast", "lunch"],
+    "description": "Sourdough or sprouted grain toast with avocado, lemon, olive oil, and optional egg or microgreens.",
+    "difficulty": "easy",
+    "pickyFriendly": true,
+    "fallback": false,
+    "ingredients": [
+      { "name": "Sourdough or sprouted grain bread", "category": "Bakery" },
+      { "name": "Avocado", "category": "Produce" },
+      { "name": "Lemon", "category": "Produce" },
+      { "name": "Olive oil", "category": "Pantry" },
+      { "name": "Eggs", "category": "Dairy" },
+      { "name": "Microgreens", "category": "Produce" }
+    ]
+  },
+  {
+    "id": "coconut-chia-pudding",
+    "name": "Coconut Chia Pudding",
+    "slots": ["breakfast", "snack"],
+    "description": "Coconut milk, chia seeds, fresh berries, and a drizzle of raw honey.",
+    "difficulty": "easy",
+    "pickyFriendly": true,
+    "fallback": true,
+    "ingredients": [
+      { "name": "Coconut milk", "category": "Pantry" },
+      { "name": "Chia seeds", "category": "Pantry" },
+      { "name": "Fresh berries", "category": "Produce" },
+      { "name": "Raw honey", "category": "Pantry" }
+    ]
+  },
+  {
+    "id": "yogurt-bowl",
+    "name": "Yogurt Bowl",
+    "slots": ["breakfast", "snack"],
+    "description": "Organic yogurt with berries and granola served on the side for full control.",
+    "difficulty": "easy",
+    "pickyFriendly": true,
+    "fallback": true,
+    "ingredients": [
+      { "name": "Organic yogurt", "category": "Dairy" },
+      { "name": "Berries", "category": "Produce" },
+      { "name": "Granola", "category": "Pantry" }
+    ]
+  },
+  {
+    "id": "chicken-bowl",
+    "name": "Build-Your-Own Chicken Bowl",
+    "slots": ["lunch", "dinner"],
+    "description": "Grilled organic chicken, greens, sweet potato, and dressing on the side.",
+    "difficulty": "medium",
+    "pickyFriendly": true,
+    "fallback": false,
+    "ingredients": [
+      { "name": "Organic chicken", "category": "Meat" },
+      { "name": "Greens", "category": "Produce" },
+      { "name": "Sweet potatoes", "category": "Produce" },
+      { "name": "Dressing", "category": "Pantry" }
+    ]
+  },
+  {
+    "id": "salmon-greens",
+    "name": "Salmon & Greens",
+    "slots": ["lunch", "dinner"],
+    "description": "Wild-caught salmon with lemon and olive oil over simple greens.",
+    "difficulty": "medium",
+    "pickyFriendly": false,
+    "fallback": false,
+    "ingredients": [
+      { "name": "Wild-caught salmon", "category": "Meat" },
+      { "name": "Lemon", "category": "Produce" },
+      { "name": "Olive oil", "category": "Pantry" },
+      { "name": "Simple greens", "category": "Produce" }
+    ]
+  },
+  {
+    "id": "veggie-soup",
+    "name": "Light Veggie Soup",
+    "slots": ["lunch", "dinner"],
+    "description": "Carrot, celery, onion, garlic, and broth. Warm, nourishing, and gentle.",
+    "difficulty": "medium",
+    "pickyFriendly": true,
+    "fallback": false,
+    "ingredients": [
+      { "name": "Carrots", "category": "Produce" },
+      { "name": "Celery", "category": "Produce" },
+      { "name": "Onion", "category": "Produce" },
+      { "name": "Garlic", "category": "Produce" },
+      { "name": "Broth", "category": "Pantry" }
+    ]
+  },
+  {
+    "id": "herb-roasted-chicken",
+    "name": "Herb Roasted Chicken",
+    "slots": ["dinner"],
+    "description": "Organic chicken roasted with rosemary, garlic, olive oil, and vegetables.",
+    "difficulty": "medium",
+    "pickyFriendly": true,
+    "fallback": false,
+    "ingredients": [
+      { "name": "Organic chicken", "category": "Meat" },
+      { "name": "Rosemary", "category": "Produce" },
+      { "name": "Garlic", "category": "Produce" },
+      { "name": "Olive oil", "category": "Pantry" },
+      { "name": "Roasting vegetables", "category": "Produce" }
+    ]
+  },
+  {
+    "id": "zucchini-noodles",
+    "name": "Zucchini Noodles",
+    "slots": ["dinner"],
+    "description": "Zoodles with olive oil, garlic, parmesan, and optional protein.",
+    "difficulty": "easy",
+    "pickyFriendly": false,
+    "fallback": false,
+    "ingredients": [
+      { "name": "Zucchini noodles", "category": "Produce" },
+      { "name": "Olive oil", "category": "Pantry" },
+      { "name": "Garlic", "category": "Produce" },
+      { "name": "Parmesan", "category": "Dairy" },
+      { "name": "Optional protein", "category": "Meat" }
+    ]
+  },
+  {
+    "id": "grass-fed-steak",
+    "name": "Grass-Fed Steak",
+    "slots": ["dinner"],
+    "description": "High-quality steak, salt and pepper, with roasted vegetables or salad.",
+    "difficulty": "medium",
+    "pickyFriendly": true,
+    "fallback": false,
+    "ingredients": [
+      { "name": "Grass-fed steak", "category": "Meat" },
+      { "name": "Salt and pepper", "category": "Pantry" },
+      { "name": "Roasted vegetables", "category": "Produce" },
+      { "name": "Salad greens", "category": "Produce" }
+    ]
+  },
+  {
+    "id": "fresh-fruit-plate",
+    "name": "Fresh Fruit Plate",
+    "slots": ["snack", "breakfast"],
+    "description": "Berries, citrus, melon. Simple, sweet, and naturally satisfying.",
+    "difficulty": "easy",
+    "pickyFriendly": true,
+    "fallback": true,
+    "ingredients": [
+      { "name": "Berries", "category": "Produce" },
+      { "name": "Citrus", "category": "Produce" },
+      { "name": "Melon", "category": "Produce" }
+    ]
+  },
+  {
+    "id": "dark-chocolate",
+    "name": "Dark Chocolate",
+    "slots": ["snack"],
+    "description": "Organic, high-cacao chocolate. Just enough indulgence.",
+    "difficulty": "easy",
+    "pickyFriendly": true,
+    "fallback": true,
+    "ingredients": [
+      { "name": "Organic dark chocolate", "category": "Pantry" }
+    ]
+  }
+]

--- a/e2e/calm-structure.spec.js
+++ b/e2e/calm-structure.spec.js
@@ -1,0 +1,38 @@
+import { expect, test } from '@playwright/test';
+
+test('calm structure local app handles meals, tasks, and safety notes', async ({ page }) => {
+  await page.goto('/calm-structure/');
+
+  await expect(page).toHaveTitle(/Calm Structure/);
+  await expect(page.getByRole('heading', { name: 'Today\'s Structure' })).toBeVisible();
+  await page.locator('#selected-date').fill('2026-06-01');
+  await page.locator('#selected-date').dispatchEvent('change');
+
+  await page.getByRole('button', { name: 'Meal Rhythm' }).click();
+  await page.locator('#meal-date').fill('2026-06-01');
+  await page.locator('#meal-slot').selectOption('dinner');
+  await page.locator('#meal-choice').selectOption('herb-roasted-chicken');
+  await page.locator('#fallback-meal').selectOption('yogurt-bowl');
+  await page.getByRole('button', { name: 'Save meal' }).click();
+  await expect(page.locator('#week-plan')).toContainText('Herb Roasted Chicken');
+
+  await page.getByRole('button', { name: 'Generate grocery list' }).click();
+  await expect(page.locator('#grocery-list')).toContainText('Organic chicken');
+  await expect(page.locator('#grocery-list')).toContainText('Organic yogurt');
+
+  await page.getByRole('button', { name: 'Owned by Me' }).click();
+  await page.locator('#task-title').fill('Pack child supplies');
+  await page.locator('#task-domain').selectOption('child');
+  await page.locator('#task-due').fill('2026-06-01');
+  await page.locator('#task-promise').fill('I will check the bag before leaving.');
+  await page.getByRole('button', { name: 'Add task' }).click();
+  await expect(page.locator('#task-list')).toContainText('Pack child supplies');
+
+  await page.getByRole('button', { name: 'Safety' }).click();
+  await expect(page.locator('#safety-resources')).toContainText('Your Safe Place');
+  await page.locator('#safety-notes').fill('Local note only');
+  await page.getByRole('button', { name: 'Save locally' }).click();
+  await page.reload();
+  await page.getByRole('button', { name: 'Safety' }).click();
+  await expect(page.locator('#safety-notes')).toHaveValue('Local note only');
+});

--- a/index.html
+++ b/index.html
@@ -150,6 +150,7 @@
       <a class="project-card" href="shared-human-values/index.html">Shared Human Values</a>
       <a class="project-card" href="consciousness/">Consciousness</a>
       <a class="project-card" href="internal-signal/index.html">Internal Signal / External World</a>
+      <a class="project-card" href="calm-structure/index.html">Calm Structure</a>
       <a class="project-card" href="journal/">Journal & Content Lab</a>
       <a class="project-card" href="stagehand.html">Stagehand Life</a>
       <a class="project-card" href="meal-tracker/index.html">Meal Tracker</a>

--- a/tests/calm-models.test.js
+++ b/tests/calm-models.test.js
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createInitialState,
+  generateShoppingItems,
+  getTodayTasks,
+  getWeekDates
+} from '../assets/js/calm-models.js';
+
+describe('calm structure models', () => {
+  it('creates initial state with a selected date and seed ownership tasks', () => {
+    const state = createInitialState(new Date('2026-06-01T12:00:00Z'));
+
+    expect(state.selectedDate).toBe('2026-06-01');
+    expect(state.tasks.map((task) => task.title)).toContain('Pick three simple dinners');
+    expect(state.repairs[0].status).toBe('open');
+  });
+
+  it('finds open tasks due today without returning completed tasks', () => {
+    const tasks = [
+      { title: 'Due', status: 'open', dueDate: '2026-06-01' },
+      { title: 'Past', status: 'open', dueDate: '2026-05-31' },
+      { title: 'Done', status: 'done', dueDate: '2026-06-01' },
+      { title: 'Future', status: 'open', dueDate: '2026-06-02' }
+    ];
+
+    expect(getTodayTasks(tasks, '2026-06-01').map((task) => task.title)).toEqual(['Due', 'Past']);
+  });
+
+  it('generates deduplicated grocery items from meals and fallbacks', () => {
+    const meals = [
+      {
+        id: 'toast',
+        name: 'Toast',
+        ingredients: [
+          { name: 'Bread', category: 'Bakery' },
+          { name: 'Eggs', category: 'Dairy' }
+        ]
+      },
+      {
+        id: 'eggs',
+        name: 'Egg Plate',
+        ingredients: [
+          { name: 'Eggs', category: 'Dairy' },
+          { name: 'Greens', category: 'Produce' }
+        ]
+      }
+    ];
+
+    const items = generateShoppingItems([
+      { mealId: 'toast', fallbackMealId: 'eggs' }
+    ], meals);
+
+    expect(items.map((item) => item.name)).toEqual(['Bread', 'Eggs', 'Greens']);
+    expect(items.find((item) => item.name === 'Eggs')?.sourceMeals).toEqual(['Toast', 'Egg Plate']);
+  });
+
+  it('returns a Sunday-start week for the selected date', () => {
+    expect(getWeekDates('2026-06-03')).toEqual([
+      '2026-05-31',
+      '2026-06-01',
+      '2026-06-02',
+      '2026-06-03',
+      '2026-06-04',
+      '2026-06-05',
+      '2026-06-06'
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `/calm-structure/` as a static local-first household rhythm app for today planning, meals, owned tasks, check-ins, support maps, repair, safety, and settings.
- Add shared Calm Structure utility/model/store modules plus future Gun/crypto placeholders that intentionally do not sync sensitive data yet.
- Seed meal ideas from the existing Clean Meals page and verified safety resource data.
- Link Calm Structure from the tmsteph homepage Explore More grid.
- Add unit and Playwright coverage for model behavior and core app flows.

## Why
This is the first implementation pass for a calm, non-blaming household operating layer: awareness -> structure -> action -> repair -> trust. The app stays local-only until GunJS/SEA encryption is implemented for shared records.

## Safety
- No analytics or trackers are added to the Calm Structure app.
- Safety notes are local-only browser storage in this phase.
- The Safety section includes quick exit, emergency guidance, and San Diego/National resources.
- The UI avoids diagnostic labels, scoring, and blame language.

## Validation
- `npm run build`
- `npm test`
- `npm run test:e2e -- e2e/explore-more-search.spec.js e2e/calm-structure.spec.js`
- `git diff --check`
- Playwright desktop/mobile screenshots of `/calm-structure/`
