### PR TITLE
[codex] Remove launch CTA from personal site

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,8 +91,7 @@
   <div class="container">
     <h1 class="handwritten">Thomas Stephens</h1>
     <p class="tagline">Dream. Build. Share.</p>
-    <p class="hero-profit-note">Need a site, offer, or business system live fast?</p>
-    <a href="https://3dvr.tech/launch-in-3-days.html" class="btn-primary">Start with Launch in 3 Days</a>
+    <p class="hero-personal-note">Personal notes, tools, and experiments from a life spent learning in public.</p>
     <a href="https://tommyos.vercel.app" class="btn-primary">Explore TommyOS</a>
     <a href="https://3dvr.tech" class="btn-secondary">Visit 3dvr.tech</a>
   </div>

--- a/style.css
+++ b/style.css
@@ -661,7 +661,7 @@ footer {
   transform: scale(1.05);
 }
 
-.hero-profit-note {
+.hero-personal-note {
   margin: 1rem auto 0.25rem;
   max-width: 34rem;
   color: #fff9c4;

--- a/tests/homepage-copy.test.js
+++ b/tests/homepage-copy.test.js
@@ -1,0 +1,15 @@
+import { readFile } from 'node:fs/promises';
+import { describe, expect, it } from 'vitest';
+
+describe('homepage personal positioning', () => {
+  it('keeps tmsteph framed as a personal site', async () => {
+    const html = await readFile('index.html', 'utf8');
+
+    expect(html).toContain(
+      'Personal notes, tools, and experiments from a life spent learning in public.'
+    );
+    expect(html).not.toContain('launch-in-3-days');
+    expect(html).not.toContain('Launch in 3 Days');
+    expect(html).not.toContain('Need a site, offer, or business system live fast?');
+  });
+});


### PR DESCRIPTION
## Summary
- Remove the homepage CTA that sent tmsteph visitors to the 3dvr Launch in 3 Days flow.
- Replace the business-fast-launch line with personal-site positioning.
- Add a regression test so the launch CTA copy/link does not come back accidentally.

## Why
The tmsteph homepage is a personal site, not a launch-service sales page. The old CTA made the first impression feel like a commercial funnel instead of a personal hub.

## Validation
- npm test
- npm run build
