### PR TITLE
[codex] Fix shopping list cross-browser sync

### DIFF
--- a/shopping-list/index.html
+++ b/shopping-list/index.html
@@ -69,6 +69,14 @@
             <h3>Household shopping list</h3>
             <p class="tracker-note">Organize your list as you shop.</p>
           </div>
+          <div class="shopping-sync-panel">
+            <label for="shopping-share-link">Current list link</label>
+            <div class="shopping-sync-row">
+              <input id="shopping-share-link" type="url" readonly aria-label="Current shopping list link">
+              <button class="shopping-action-btn" type="button" id="shopping-copy-link">Copy link</button>
+            </div>
+            <p class="tracker-note" id="shopping-sync-status" aria-live="polite"></p>
+          </div>
           <div class="tracker-filter">
             <label for="shopping-sort">Sort list by</label>
             <select id="shopping-sort" name="shopping-sort">

--- a/shopping-list/shopping-list.js
+++ b/shopping-list/shopping-list.js
@@ -80,11 +80,47 @@ export const initShoppingList = ({
   const list = documentRef.getElementById('shopping-list');
   const emptyState = documentRef.getElementById('shopping-empty');
   const sortSelect = documentRef.getElementById('shopping-sort');
+  const shareInput = documentRef.getElementById('shopping-share-link');
+  const copyLinkButton = documentRef.getElementById('shopping-copy-link');
+  const syncStatus = documentRef.getElementById('shopping-sync-status');
 
   const listId = getListId();
-  const entries = gun.get('shopping-list').get(listId).get('items');
+  const getShareUrl = () => {
+    const url = new URL(windowRef?.location?.href || 'https://example.com/shopping-list/');
+    url.searchParams.set(LIST_PARAM, listId);
+    return url.toString();
+  };
+  const shareUrl = getShareUrl();
+  const listRoot = gun.get('shopping-list').get(listId);
+  const entries = listRoot.get('items');
+  const itemIndex = listRoot.get('item-index');
   const cache = new Map();
+  const subscribedItems = new Set();
   let editingId = null;
+
+  if (shareInput) {
+    shareInput.value = shareUrl;
+  }
+
+  copyLinkButton?.addEventListener('click', async () => {
+    try {
+      if (windowRef?.navigator?.clipboard?.writeText) {
+        await windowRef.navigator.clipboard.writeText(shareUrl);
+      } else if (shareInput?.select && documentRef.execCommand) {
+        shareInput.select();
+        documentRef.execCommand('copy');
+      } else {
+        throw new Error('Clipboard unavailable');
+      }
+      if (syncStatus) {
+        syncStatus.textContent = 'Current list link copied.';
+      }
+    } catch (err) {
+      if (syncStatus) {
+        syncStatus.textContent = 'Copy failed. Select the link above.';
+      }
+    }
+  });
 
   const resetForm = () => {
     form.reset();
@@ -230,6 +266,7 @@ export const initShoppingList = ({
       deleteButton.className = 'shopping-action-btn shopping-action-btn--ghost';
       deleteButton.textContent = 'Delete';
       deleteButton.addEventListener('click', () => {
+        itemIndex.put({ [item.id]: false });
         entries.get(item.id).put(null);
         if (editingId === item.id) {
           setEditState(null);
@@ -243,7 +280,7 @@ export const initShoppingList = ({
     }
   };
 
-  entries.map().on((data, key) => {
+  const applyItemData = (data, key) => {
     if (!data) {
       cache.delete(key);
       renderItems();
@@ -264,6 +301,30 @@ export const initShoppingList = ({
     });
 
     renderItems();
+  };
+
+  const subscribeToItem = (key) => {
+    if (!key || subscribedItems.has(key)) {
+      return;
+    }
+    subscribedItems.add(key);
+    entries.get(key).on((data) => {
+      applyItemData(data, key);
+    });
+  };
+
+  itemIndex.map().on((active, key) => {
+    if (!active) {
+      cache.delete(key);
+      renderItems();
+      return;
+    }
+
+    subscribeToItem(key);
+  });
+
+  entries.map().on((data, key) => {
+    applyItemData(data, key);
   });
 
   sortSelect?.addEventListener('change', () => {
@@ -297,6 +358,7 @@ export const initShoppingList = ({
         purchased: existing.purchased ?? false,
         purchasedAt: existing.purchasedAt ?? null,
       });
+      itemIndex.put({ [editingId]: true });
       setEditState(null);
       return;
     }
@@ -311,6 +373,7 @@ export const initShoppingList = ({
       notes,
       createdAt: Date.now(),
     });
+    itemIndex.put({ [id]: true });
     resetForm();
   });
 
@@ -323,7 +386,7 @@ export const initShoppingList = ({
     dateInput.value = today;
   }
 
-  return {};
+  return { listId, shareUrl };
 };
 
 if (typeof window !== 'undefined') {

--- a/style.css
+++ b/style.css
@@ -1743,6 +1743,51 @@ footer {
   box-shadow: inset 0 0 0 1px rgba(127, 255, 225, 0.08);
 }
 
+.shopping-sync-panel {
+  display: grid;
+  gap: 0.5rem;
+  margin-top: 1rem;
+  padding: 0.9rem;
+  border-radius: 14px;
+  border: 1px solid rgba(127, 255, 225, 0.16);
+  background: rgba(11, 29, 57, 0.32);
+  text-align: left;
+}
+
+.shopping-sync-panel label {
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+
+.shopping-sync-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.6rem;
+  align-items: center;
+}
+
+.shopping-sync-row input {
+  min-width: 0;
+  width: 100%;
+  padding: 0.6rem 0.75rem;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  background: rgba(255, 255, 255, 0.08);
+  color: #ffe066;
+  font-weight: 600;
+}
+
+.shopping-sync-panel .tracker-note {
+  min-height: 1.2em;
+  margin: 0;
+}
+
+@media (max-width: 560px) {
+  .shopping-sync-row {
+    grid-template-columns: 1fr;
+  }
+}
+
 .cycle-results {
   display: flex;
   flex-direction: column;

--- a/tests/shopping-list.test.js
+++ b/tests/shopping-list.test.js
@@ -15,6 +15,9 @@ const baseMarkup = `
     <textarea id="item-notes"></textarea>
     <button type="submit">Submit</button>
   </form>
+  <input id="shopping-share-link" />
+  <button id="shopping-copy-link" type="button">Copy link</button>
+  <p id="shopping-sync-status"></p>
   <div id="shopping-empty"></div>
   <ul id="shopping-list"></ul>
 `;
@@ -27,22 +30,39 @@ const createDom = (url = 'https://example.com/shopping-list/') =>
 const createGunMock = () => {
   const put = vi.fn();
   const on = vi.fn();
-  const itemsNode = {
+  const paths = [];
+  const puts = [];
+  const createNode = (path = []) => ({
     map: () => ({ on }),
-    get: vi.fn(() => ({ put })),
-  };
-  const listIdNode = {
-    get: vi.fn(() => itemsNode),
-  };
-  const listNode = {
-    get: vi.fn(() => listIdNode),
-  };
-  const rootNode = {
-    get: vi.fn(() => listNode),
-  };
-  const Gun = vi.fn(() => rootNode);
+    get: vi.fn((key) => {
+      const nextPath = [...path, key];
+      paths.push(nextPath);
+      return createNode(nextPath);
+    }),
+    put: (value) => {
+      puts.push({ path, value });
+      return put(value);
+    },
+  });
+  const Gun = vi.fn(() => createNode());
 
-  return { Gun, put };
+  return { Gun, put, paths, puts };
+};
+
+const pathWasRequested = (paths, expectedPath) =>
+  paths.some((path) => path.join('/') === expectedPath.join('/'));
+
+const createClipboardMock = (dom) => {
+  const clipboard = {
+    writeText: vi.fn().mockResolvedValue(undefined),
+  };
+
+  Object.defineProperty(dom.window.navigator, 'clipboard', {
+    configurable: true,
+    value: clipboard,
+  });
+
+  return clipboard;
 };
 
 describe('shopping list sync', () => {
@@ -59,7 +79,7 @@ describe('shopping list sync', () => {
 
   it('uses the list id from the URL when present', () => {
     const dom = createDom('https://example.com/shopping-list/?list=family123');
-    const { Gun } = createGunMock();
+    const { Gun, paths } = createGunMock();
 
     initShoppingList({
       Gun,
@@ -68,6 +88,7 @@ describe('shopping list sync', () => {
     });
 
     expect(dom.window.location.search).toContain('list=family123');
+    expect(pathWasRequested(paths, ['shopping-list', 'family123', 'items'])).toBe(true);
   });
 
   it('adds a list id to the URL when missing', () => {
@@ -85,7 +106,7 @@ describe('shopping list sync', () => {
 
   it('stores submitted items in Gun', () => {
     const dom = createDom('https://example.com/shopping-list/?list=family123');
-    const { Gun, put } = createGunMock();
+    const { Gun, put, puts } = createGunMock();
     const documentRef = dom.window.document;
 
     documentRef.getElementById('item-name').value = 'Milk';
@@ -115,12 +136,25 @@ describe('shopping list sync', () => {
         notes: 'Organic',
       })
     );
+
+    const itemPut = puts.find(
+      (entry) =>
+        entry.path.slice(0, -1).join('/') === 'shopping-list/family123/items' &&
+        entry.value?.name === 'Milk'
+    );
+    const itemId = itemPut?.path.at(-1);
+    const indexPut = puts.find((entry) =>
+      pathWasRequested([entry.path], ['shopping-list', 'family123', 'item-index'])
+    );
+
+    expect(itemPut).toBeTruthy();
+    expect(indexPut?.value?.[itemId]).toBe(true);
   });
 
   it('reuses the stored list id when returning', () => {
     const dom = createDom('https://example.com/shopping-list/');
     dom.window.localStorage.setItem('shoppingListId', 'returning-456');
-    const { Gun } = createGunMock();
+    const { Gun, paths } = createGunMock();
 
     initShoppingList({
       Gun,
@@ -129,5 +163,62 @@ describe('shopping list sync', () => {
     });
 
     expect(dom.window.location.search).toContain('list=returning-456');
+    expect(pathWasRequested(paths, ['shopping-list', 'returning-456', 'items'])).toBe(true);
+  });
+
+  it('exposes a copyable sync link for the current list', async () => {
+    const dom = createDom('https://example.com/shopping-list/?list=family123');
+    const clipboard = createClipboardMock(dom);
+    const { Gun } = createGunMock();
+
+    const result = initShoppingList({
+      Gun,
+      document: dom.window.document,
+      window: dom.window,
+    });
+
+    const shareInput = dom.window.document.getElementById('shopping-share-link');
+    const copyButton = dom.window.document.getElementById('shopping-copy-link');
+    const syncStatus = dom.window.document.getElementById('shopping-sync-status');
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        listId: 'family123',
+        shareUrl: 'https://example.com/shopping-list/?list=family123',
+      })
+    );
+    expect(shareInput.value).toBe('https://example.com/shopping-list/?list=family123');
+
+    copyButton.dispatchEvent(new dom.window.Event('click', { bubbles: true }));
+    await vi.waitFor(() => {
+      expect(clipboard.writeText).toHaveBeenCalledWith(
+        'https://example.com/shopping-list/?list=family123'
+      );
+      expect(syncStatus.textContent).toBe('Current list link copied.');
+    });
+  });
+
+  it('uses the same Gun list path across isolated browsers when opened from the sync link', () => {
+    const sharedUrl = 'https://example.com/shopping-list/?list=family123';
+    const chromePwa = createDom(sharedUrl);
+    const braveBrowser = createDom(sharedUrl);
+    const chromeGun = createGunMock();
+    const braveGun = createGunMock();
+
+    const chromeResult = initShoppingList({
+      Gun: chromeGun.Gun,
+      document: chromePwa.window.document,
+      window: chromePwa.window,
+    });
+    const braveResult = initShoppingList({
+      Gun: braveGun.Gun,
+      document: braveBrowser.window.document,
+      window: braveBrowser.window,
+    });
+
+    expect(chromeResult.listId).toBe('family123');
+    expect(braveResult.listId).toBe('family123');
+    expect(pathWasRequested(chromeGun.paths, ['shopping-list', 'family123', 'items'])).toBe(true);
+    expect(pathWasRequested(braveGun.paths, ['shopping-list', 'family123', 'items'])).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- Add a visible current-list link and copy action to the shopping list.
- Keep a Gun `item-index` beside item data so other browser profiles can discover item IDs remotely.
- Expand shopping-list tests for shared list identity, copyable sync links, and index writes.

## Why
Chrome PWA and Brave do not share localStorage, so opening `/shopping-list/` in each browser can silently create two different list IDs. Even when both profiles use the same `?list=` URL, the old `entries.get(id).put(...)` collection pattern did not let a remote `entries.map().on(...)` discover newly created item keys through the relay.

## Validation
- `npm test`
- `npm run build`
- Local browser relay check: two isolated Termux Chromium contexts opened the same shopping-list URL, added an item in one context, and observed it in the other through `gun-relay-3dvr.fly.dev`.
- Layout smoke check: desktop and mobile viewports keep the new sync-link input and copy button inside their container without overlap.
