### PR TITLE
[codex] Remove homepage personal note

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,7 +91,6 @@
   <div class="container">
     <h1 class="handwritten">Thomas Stephens</h1>
     <p class="tagline">Dream. Build. Share.</p>
-    <p class="hero-personal-note">Personal notes, tools, and experiments from a life spent learning in public.</p>
     <a href="https://tommyos.vercel.app" class="btn-primary">Explore TommyOS</a>
     <a href="https://3dvr.tech" class="btn-secondary">Visit 3dvr.tech</a>
   </div>

--- a/tests/homepage-copy.test.js
+++ b/tests/homepage-copy.test.js
@@ -5,7 +5,7 @@ describe('homepage personal positioning', () => {
   it('keeps tmsteph framed as a personal site', async () => {
     const html = await readFile('index.html', 'utf8');
 
-    expect(html).toContain(
+    expect(html).not.toContain(
       'Personal notes, tools, and experiments from a life spent learning in public.'
     );
     expect(html).not.toContain('launch-in-3-days');


### PR DESCRIPTION
## Summary
- Removes the homepage hero note: "Personal notes, tools, and experiments from a life spent learning in public."
- Updates the homepage copy test so the removed sentence does not come back accidentally.

## Validation
- `npm test`
- `git diff --check`
