### PR TITLE
[codex] Center Command Central link rows

### DIFF
--- a/style.css
+++ b/style.css
@@ -1609,8 +1609,9 @@ footer {
    COMMAND CENTRAL LINKS
 =========================== */
 .quick-links {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
   gap: 1.25rem;
   margin-top: 2rem;
 }
@@ -1628,7 +1629,9 @@ footer {
   font-weight: 700;
   letter-spacing: 0.02em;
   transition: transform 0.3s ease, background 0.3s ease, border 0.3s ease;
+  flex: 0 1 190px;
   min-height: 58px;
+  text-align: center;
 }
 
 .quick-link:hover {
@@ -2251,11 +2254,11 @@ footer {
   }
 
   .quick-links {
-    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
     gap: 1rem;
   }
 
   .quick-link {
+    flex-basis: 160px;
     padding: 0.85rem 1rem;
     min-height: 52px;
   }

--- a/tests/homepage-copy.test.js
+++ b/tests/homepage-copy.test.js
@@ -26,4 +26,13 @@ describe('homepage personal positioning', () => {
     expect(trackerHtml).toContain('RCD incubator plots');
     expect(trackerHtml).toContain('Local Models to Visit');
   });
+
+  it('centers incomplete Command Central link rows', async () => {
+    const css = await readFile('style.css', 'utf8');
+
+    expect(css).toContain('.quick-links');
+    expect(css).toContain('display: flex;');
+    expect(css).toContain('flex-wrap: wrap;');
+    expect(css).toContain('justify-content: center;');
+  });
 });


### PR DESCRIPTION
## Summary
- Changes Command Central quick links from an auto-fit grid to centered wrapping flex rows.
- Keeps link widths consistent while centering incomplete rows, including one-item rows.
- Adds a regression test for the centered wrapping layout.

## Validation
- `npm test`
- `git diff --check`
- Browser layout probe with Command Central forced visible at 1280, 390, and 344 widths
- Additional width sweep from 760 through 1140 with no horizontal overflow
