### PR TITLE
[codex] Add app search shortcut

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,6 +92,7 @@
     <h1 class="handwritten">Thomas Stephens</h1>
     <p class="tagline">Dream. Build. Share.</p>
     <a href="https://tommyos.vercel.app" class="btn-primary">Explore TommyOS</a>
+    <a href="#explore-more" class="btn-secondary" data-app-search-jump>Search Apps</a>
     <a href="https://3dvr.tech" class="btn-secondary">Visit 3dvr.tech</a>
   </div>
 </header>
@@ -125,7 +126,7 @@
 </section>
 
 <!-- Explore More -->
-<section class="section card">
+<section class="section card" id="explore-more">
   <div class="container">
     <h2>Explore More</h2>
     <div class="explore-search" role="search" aria-label="Search apps">

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ const exploreSearchInput = document.getElementById('explore-search-input');
 const exploreSearchStatus = document.getElementById('explore-search-status');
 const exploreSearchEmpty = document.getElementById('explore-search-empty');
 const exploreGrid = document.getElementById('explore-project-grid');
+const appSearchJump = document.querySelector('[data-app-search-jump]');
 
 if (exploreSearchInput && exploreSearchStatus && exploreSearchEmpty && exploreGrid) {
   const projectCards = Array.from(exploreGrid.querySelectorAll('.project-card'));
@@ -32,4 +33,25 @@ if (exploreSearchInput && exploreSearchStatus && exploreSearchEmpty && exploreGr
 
   exploreSearchInput.addEventListener('input', updateSearchResults);
   updateSearchResults();
+
+  if (appSearchJump) {
+    appSearchJump.addEventListener('click', (event) => {
+      event.preventDefault();
+
+      const searchContainer = exploreSearchInput.closest('.explore-search');
+      document.getElementById('explore-more')?.scrollIntoView({
+        behavior: 'smooth',
+        block: 'start'
+      });
+
+      window.setTimeout(() => {
+        exploreSearchInput.focus({ preventScroll: true });
+        searchContainer?.classList.add('is-highlighted');
+      }, 260);
+
+      window.setTimeout(() => {
+        searchContainer?.classList.remove('is-highlighted');
+      }, 1800);
+    });
+  }
 }

--- a/style.css
+++ b/style.css
@@ -849,6 +849,29 @@ footer {
   box-shadow: 0 0 0 3px rgba(255, 224, 102, 0.25);
 }
 
+.explore-search.is-highlighted .explore-search-input {
+  border-color: rgba(255, 224, 102, 0.9);
+  background: rgba(255, 255, 255, 0.2);
+  box-shadow:
+    0 0 0 4px rgba(255, 224, 102, 0.28),
+    0 18px 34px -22px rgba(0, 0, 0, 0.55);
+  animation: app-search-highlight 1200ms ease-out;
+}
+
+@keyframes app-search-highlight {
+  0% {
+    transform: scale(1);
+  }
+
+  35% {
+    transform: scale(1.025);
+  }
+
+  100% {
+    transform: scale(1);
+  }
+}
+
 .explore-search-status {
   margin-bottom: 0;
   font-size: 0.95rem;

--- a/tests/homepage-copy.test.js
+++ b/tests/homepage-copy.test.js
@@ -35,4 +35,17 @@ describe('homepage personal positioning', () => {
     expect(css).toContain('flex-wrap: wrap;');
     expect(css).toContain('justify-content: center;');
   });
+
+  it('provides a top app search shortcut that focuses the app search', async () => {
+    const html = await readFile('index.html', 'utf8');
+    const js = await readFile('index.js', 'utf8');
+    const css = await readFile('style.css', 'utf8');
+
+    expect(html).toContain('href="#explore-more"');
+    expect(html).toContain('data-app-search-jump');
+    expect(html).toContain('id="explore-more"');
+    expect(js).toContain('exploreSearchInput.focus');
+    expect(js).toContain("classList.add('is-highlighted')");
+    expect(css).toContain('.explore-search.is-highlighted .explore-search-input');
+  });
 });


### PR DESCRIPTION
## Summary
- Adds a top hero button that jumps directly to the app search section.
- Gives the Explore More section a stable anchor for the shortcut.
- Focuses and briefly highlights the app search input after the jump.
- Adds regression coverage for the shortcut markup, JS hook, and highlight style.

## Validation
- `npm test`
- `git diff --check`
- Browser click probe at 1280x900 and 390x844 confirmed the button scrolls to the app section, focuses `#explore-search-input`, applies the highlight class, and creates no horizontal overflow.
