### PR TITLE
[codex] Tighten farm mobile layout

### DIFF
--- a/regenerative-farm/index.html
+++ b/regenerative-farm/index.html
@@ -462,7 +462,7 @@
 
     @media (max-width: 480px) {
       .wrap {
-        width: min(var(--max), calc(100% - 20px));
+        width: min(var(--max), calc(100% - 24px));
       }
 
       .hero-copy,
@@ -474,26 +474,31 @@
       }
 
       header {
-        padding: 24px 0 18px;
+        padding: 18px 0 12px;
       }
 
       .hero {
-        gap: 14px;
+        gap: 10px;
       }
 
       .hero-copy,
       .hero-card {
-        border-radius: 22px;
-        padding: 18px;
+        border-radius: 20px;
+        padding: 16px;
+      }
+
+      .eyebrow {
+        font-size: 0.68rem;
+        letter-spacing: 0.14em;
       }
 
       h1 {
-        font-size: 2.7rem;
-        line-height: 0.98;
+        font-size: clamp(2.35rem, 15vw, 2.9rem);
+        line-height: 0.95;
       }
 
       h2 {
-        font-size: 1.75rem;
+        font-size: 1.55rem;
         line-height: 1.05;
       }
 
@@ -502,19 +507,65 @@
         font-size: 1rem;
       }
 
+      .lede {
+        line-height: 1.48;
+      }
+
+      .pill-row {
+        gap: 8px;
+        margin-top: 14px;
+      }
+
       .pill {
         max-width: 100%;
+        padding: 7px 9px;
+        font-size: 0.86rem;
         white-space: normal;
       }
 
-      .tagline,
+      .tagline {
+        margin-top: 16px;
+        padding: 14px;
+        font-size: 1rem;
+      }
+
+      .grid {
+        gap: 14px;
+      }
+
       .card,
+      .note-box {
+        padding: 16px;
+      }
+
+      .tracker {
+        border-radius: 18px;
+      }
+
+      .stats {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: 8px;
+      }
+
+      .stat {
+        padding: 10px 8px;
+        border-radius: 14px;
+        font-size: 0.78rem;
+        line-height: 1.35;
+      }
+
+      .stat strong {
+        font-size: 1.3rem;
+        margin-bottom: 4px;
+      }
+
       .note-box {
         padding: 18px;
       }
 
       .farm-window {
-        min-height: 240px;
+        min-height: 178px;
+        border-radius: 18px;
       }
 
       .farm-window::after {
@@ -526,16 +577,27 @@
       }
 
       section {
-        padding: 42px 0;
+        padding: 34px 0;
       }
 
       nav .wrap {
-        padding: 10px 0;
+        gap: 8px;
+        padding: 9px 0;
+        scrollbar-width: none;
+      }
+
+      nav .wrap::-webkit-scrollbar {
+        display: none;
+      }
+
+      nav a {
+        padding: 7px 10px;
+        font-size: 0.86rem;
       }
 
       .contact-script {
         padding: 14px;
-        font-size: 0.78rem;
+        font-size: 0.72rem;
       }
     }
 

--- a/tests/homepage-copy.test.js
+++ b/tests/homepage-copy.test.js
@@ -27,6 +27,15 @@ describe('homepage personal positioning', () => {
     expect(trackerHtml).toContain('Local Models to Visit');
   });
 
+  it('keeps the regenerative farm page compact on narrow displays', async () => {
+    const trackerHtml = await readFile('regenerative-farm/index.html', 'utf8');
+
+    expect(trackerHtml).toContain('@media (max-width: 480px)');
+    expect(trackerHtml).toContain('grid-template-columns: repeat(3, minmax(0, 1fr));');
+    expect(trackerHtml).toContain('min-height: 178px;');
+    expect(trackerHtml).toContain('font-size: clamp(2.35rem, 15vw, 2.9rem);');
+  });
+
   it('centers incomplete Command Central link rows', async () => {
     const css = await readFile('style.css', 'utf8');
 


### PR DESCRIPTION
## Summary
- Tightens the Regenerative Farm page's narrow-display layout.
- Reduces mobile hero padding/type bulk, shortens the farm image, and makes the stat cards compact in one row.
- Tightens mobile cards, section spacing, nav chips, and the email template text sizing.
- Adds regression coverage for the compact mobile farm CSS.

## Validation
- `npm test`
- `git diff --check`
- Browser screenshots and layout metrics at 390x844, 344x882, 320x740, and 1366x768
- Confirmed no page-level horizontal overflow at those widths
