### PR TITLE
[codex] Add farm relocation incentive research

### DIFF
--- a/regenerative-farm/index.html
+++ b/regenerative-farm/index.html
@@ -408,6 +408,25 @@
       font-size: 1.04rem;
     }
 
+    .program-type {
+      display: inline-flex;
+      width: fit-content;
+      margin-bottom: 14px;
+      padding: 6px 10px;
+      border-radius: 999px;
+      border: 1px solid rgba(49, 75, 43, 0.18);
+      background: rgba(115, 132, 95, 0.12);
+      color: var(--green);
+      font-size: 0.78rem;
+      font-weight: 700;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    .program-list {
+      margin-top: 18px;
+    }
+
     @media (max-width: 860px) {
       .hero,
       .grid.two,
@@ -675,6 +694,7 @@
       <a href="#land">Land Leads</a>
       <a href="#land-reality">Land Reality</a>
       <a href="#areas">Target Areas</a>
+      <a href="#relocation-research">Relocation Research</a>
       <a href="#farm-models">Farm Models</a>
       <a href="#outreach">Outreach</a>
       <a href="#retreats">Retreats</a>
@@ -925,8 +945,10 @@
         <h2>Target Areas to Compare</h2>
         <p class="research-note">
           San Diego is still the first research base, but the farm search should stay open.
-          South Dakota, Tennessee, Italy, and Baja all deserve comparison before any major
-          land decision.
+          South Dakota, Tennessee, Italy, Baja, and other rural regions deserve comparison
+          before any major land decision. Treat "move here" grants carefully: most real
+          programs are loans, tax credits, cost shares, or local relocation incentives, not
+          free farmland.
         </p>
         <div class="grid three">
           <article class="card">
@@ -987,6 +1009,121 @@
               A longer-term dream path for food, culture, beauty, and rural renewal. Research
               visas, citizenship options, language, land rules, taxes, healthcare, farm income,
               and whether it should begin as seasonal learning before relocation.
+            </p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section id="relocation-research">
+      <div class="wrap">
+        <h2>Relocation and Farm Incentive Leads</h2>
+        <p class="research-note">
+          The pattern is clear: true farm land grants are rare. Better leads combine rural
+          relocation demand with beginning-farmer financing, landowner tax credits,
+          cost-share programs, or young-farmer startup support.
+        </p>
+
+        <div class="grid three program-list">
+          <article class="card">
+            <span class="program-type">South Dakota</span>
+            <h3>Lower-pressure land plus beginning-farmer bonds</h3>
+            <p>
+              South Dakota is not showing up as a simple free-land path, but it does have
+              a state Beginning Farmer Bond Program that helps qualifying farmers acquire
+              agricultural property at lower interest rates. The state also lists specialty
+              crop, local food, grazing, and other producer resources.
+            </p>
+            <ul>
+              <li>Best research angle: affordable land, livestock, grains, local food, and winter-hardy systems.</li>
+              <li>Watchouts: winter severity, short growing season, distance from family network, healthcare, schools, and isolation.</li>
+            </ul>
+          </article>
+
+          <article class="card">
+            <span class="program-type">Italy</span>
+            <h3>Young-farmer land finance and rural village renewal</h3>
+            <p>
+              Italy has stronger farm-specific national leads through ISMEA, including
+              Generazione Terra for young farmers buying agricultural land and Piu Impresa
+              for young and women-led agricultural businesses. Separate regional village
+              programs, such as Calabria's mountain-borough repopulation effort, can support
+              relocation or entrepreneurship but are not automatically farm grants.
+            </p>
+            <ul>
+              <li>Best research angle: seasonal learning first, then young-farmer finance, rural enterprise, citizenship, language, and tax reality.</li>
+              <li>Regions to watch: Calabria, Sardinia, Sicily, Molise, Tuscany mountain towns, and Trentino-style village renewal programs.</li>
+            </ul>
+          </article>
+
+          <article class="card">
+            <span class="program-type">Tennessee</span>
+            <h3>Homestead culture plus cost-share and enterprise grants</h3>
+            <p>
+              Tennessee looks less like a relocation-grant state and more like a practical
+              farm-development state. TAEP has a Beginning Farmer Option with reduced
+              livestock thresholds, while the Agricultural Enterprise Fund supports
+              value-added, processing, food, forestry, and market-building projects.
+            </p>
+            <ul>
+              <li>Best research angle: family land, music culture, workshops, livestock, agroforestry, and value-added farm business.</li>
+              <li>Watchouts: humidity, storms, politics, zoning for gatherings, and whether raw production alone is competitive.</li>
+            </ul>
+          </article>
+
+          <article class="card">
+            <span class="program-type">Kansas</span>
+            <h3>Rural Opportunity Zones</h3>
+            <p>
+              Kansas is one of the clearest relocation-incentive leads. Its Rural Opportunity
+              Zones cover many rural counties and can offer student loan repayment assistance
+              and/or a 100% state income tax credit for qualifying new full-time residents.
+            </p>
+            <ul>
+              <li>Best research angle: combine a ROZ county with farmable land, USDA/FSA financing, and local market access.</li>
+              <li>Watchouts: ROZ is a residency incentive, not a farm-start grant.</li>
+            </ul>
+          </article>
+
+          <article class="card">
+            <span class="program-type">Minnesota</span>
+            <h3>Beginning-farmer finance stack</h3>
+            <p>
+              Minnesota has a serious beginning-farmer support stack through the Rural
+              Finance Authority: beginning farmer loans, tax credits for asset owners who
+              rent or sell to beginning farmers, farm listings, and grant programs like
+              down-payment or equipment support when available.
+            </p>
+            <ul>
+              <li>Best research angle: land access, cold-climate regenerative systems, training, farm business management, and co-op culture.</li>
+              <li>Watchouts: climate, distance, and whether the project wants a northern growing season.</li>
+            </ul>
+          </article>
+
+          <article class="card">
+            <span class="program-type">Nebraska / Iowa</span>
+            <h3>Landowner tax credits and reduced-rate loans</h3>
+            <p>
+              Nebraska's NextGen Beginning Farmer program and Iowa's beginning farmer
+              programs both try to make land and farm assets more accessible by helping
+              landowners lease or sell to new farmers and by supporting reduced-rate loan
+              structures.
+            </p>
+            <ul>
+              <li>Best research angle: lease-first farm start, succession, ranch/farm transition, and low-overhead family agriculture.</li>
+              <li>Watchouts: these are access and finance tools, not automatic relocation payments.</li>
+            </ul>
+          </article>
+        </div>
+
+        <div style="margin-top:18px;">
+          <article class="note-box">
+            <h2>Research Rule</h2>
+            <p>
+              Verify each lead as one of four categories before getting excited:
+              relocation incentive, farm finance, land-access/tax-credit program, or
+              actual grant. If it does not reduce land access friction or help the farm
+              earn responsibly, it is probably just a headline.
             </p>
           </article>
         </div>
@@ -1172,7 +1309,8 @@ Thomas</div>
             <li>Visit at least five local models before choosing land.</li>
             <li>Build a spreadsheet of leads, dates, responses, next steps, and follow-ups.</li>
             <li>Draft a 12-month pilot that could work before owning land.</li>
-            <li>Compare San Diego County with South Dakota, Tennessee, Italy, and Baja before narrowing the land search.</li>
+            <li>Compare San Diego County with South Dakota, Tennessee, Italy, Baja, Kansas, Minnesota, Nebraska, and Iowa before narrowing the land search.</li>
+            <li>Classify every incentive as relocation-only, farm finance, land-access support, cost share, or actual grant before planning around it.</li>
           </ol>
         </article>
 
@@ -1247,6 +1385,19 @@ Thomas</div>
             <li><a href="https://www.theagrarianinstitute.org/">The Agrarian Institute</a></li>
             <li><a href="https://sagemountainfarm.com/">Sage Mountain Farm</a></li>
             <li><a href="https://www.goodneighborgardens.com/">Good Neighbor Gardens</a></li>
+            <li><a href="https://sdgoed.com/program/beginning-farmer-bond-program/">South Dakota Beginning Farmer Bond Program</a></li>
+            <li><a href="https://danr.sd.gov/AboutDANR/ProducerResources.aspx">South Dakota DANR producer resources</a></li>
+            <li><a href="https://www.ismea.it/Startup/GenerazioneTerra">ISMEA Generazione Terra</a></li>
+            <li><a href="https://www.ismea.it/flex/cm/pages/ServeBLOB.php/L/IT/IDPagina/9406">ISMEA Piu Impresa</a></li>
+            <li><a href="https://www.regione.calabria.it/abita-borghi-montani-calabria-approvata-la-graduatoria-definitiva-89-comuni-ammessi-al-bando-regionale/">Regione Calabria: Abita Borghi Montani</a></li>
+            <li><a href="https://www.tn.gov/agriculture/farms/taep/producer-programs/beginning-farmer-option.html">Tennessee TAEP Beginning Farmer Option</a></li>
+            <li><a href="https://www.tn.gov/agriculture/businesses/aef.html">Tennessee Agricultural Enterprise Fund</a></li>
+            <li><a href="https://www.kansascommerce.gov/program/taxes-and-financing/rural-opportunity-zones-roz/">Kansas Rural Opportunity Zones</a></li>
+            <li><a href="https://www.mda.state.mn.us/business-dev-loans-grants/beginning-farmer-loan-program">Minnesota Beginning Farmer Loan Program</a></li>
+            <li><a href="https://www.mda.state.mn.us/bftc">Minnesota Beginning Farmer Tax Credit</a></li>
+            <li><a href="https://nextgen.nebraska.gov/">Nebraska NextGen Beginning Farmer Program</a></li>
+            <li><a href="https://opportunityiowa.gov/business/small-business-entrepreneurs/beginning-farmers">Iowa beginning farmer programs</a></li>
+            <li><a href="https://www.fsa.usda.gov/resources/beginning-farmers-and-ranchers-loans">USDA FSA Beginning Farmers and Ranchers Loans</a></li>
           </ul>
         </article>
       </div>

--- a/tests/homepage-copy.test.js
+++ b/tests/homepage-copy.test.js
@@ -36,6 +36,19 @@ describe('homepage personal positioning', () => {
     expect(trackerHtml).toContain('font-size: clamp(2.35rem, 15vw, 2.9rem);');
   });
 
+  it('tracks relocation and farm incentive research leads', async () => {
+    const trackerHtml = await readFile('regenerative-farm/index.html', 'utf8');
+
+    expect(trackerHtml).toContain('Relocation and Farm Incentive Leads');
+    expect(trackerHtml).toContain('South Dakota Beginning Farmer Bond Program');
+    expect(trackerHtml).toContain('ISMEA Generazione Terra');
+    expect(trackerHtml).toContain('Kansas Rural Opportunity Zones');
+    expect(trackerHtml).toContain('Minnesota Beginning Farmer Tax Credit');
+    expect(trackerHtml).toContain('Nebraska NextGen Beginning Farmer Program');
+    expect(trackerHtml).toContain('Iowa beginning farmer programs');
+    expect(trackerHtml).toContain('Classify every incentive as relocation-only');
+  });
+
   it('centers incomplete Command Central link rows', async () => {
     const css = await readFile('style.css', 'utf8');
 


### PR DESCRIPTION
## Summary
- Add a relocation and farm incentive research section to the regenerative farm tracker
- Expand the comparison set beyond San Diego, South Dakota, Tennessee, Italy, and Baja to include Kansas, Minnesota, Nebraska, and Iowa
- Add official source links for South Dakota, Italy, Tennessee, Kansas, Minnesota, Nebraska, Iowa, and USDA beginning-farmer programs
- Add a copy regression test for the new research leads

## Validation
- `npm test`
- `git diff --check`
- Playwright layout metrics at 1280, 390, 344, and 320px with no horizontal overflow
