### PR TITLE
[codex] Soften regenerative farm background

### DIFF
--- a/regenerative-farm/index.html
+++ b/regenerative-farm/index.html
@@ -6,8 +6,8 @@
   <title>Regenerative Farm Tracker</title>
   <style>
     :root {
-      --bg: #f5f1e8;
-      --paper: #fffaf0;
+      --bg: #eee4d0;
+      --paper: #fbf2df;
       --ink: #26301f;
       --muted: #6f735f;
       --green: #314b2b;
@@ -34,9 +34,9 @@
       font-family: Georgia, "Times New Roman", serif;
       color: var(--ink);
       background:
-        radial-gradient(circle at top left, rgba(183, 141, 70, 0.22), transparent 32rem),
-        radial-gradient(circle at 85% 12%, rgba(115, 132, 95, 0.24), transparent 30rem),
-        linear-gradient(180deg, #fbf7ed 0%, var(--bg) 48%, #e9e0cc 100%);
+        radial-gradient(circle at top left, rgba(183, 141, 70, 0.13), transparent 32rem),
+        radial-gradient(circle at 85% 12%, rgba(115, 132, 95, 0.15), transparent 30rem),
+        linear-gradient(180deg, #f0e7d5 0%, var(--bg) 48%, #dfd2b8 100%);
       line-height: 1.55;
       overflow-x: hidden;
     }
@@ -73,7 +73,7 @@
     .card,
     .tracker,
     .note-box {
-      background: rgba(255, 250, 240, 0.82);
+      background: rgba(251, 242, 223, 0.84);
       border: 1px solid var(--line);
       box-shadow: var(--shadow);
       backdrop-filter: blur(10px);
@@ -152,7 +152,7 @@
         url("https://images.unsplash.com/photo-1500382017468-9049fed747ef?auto=format&fit=crop&w=1300&q=80") center/cover;
       position: relative;
       overflow: hidden;
-      border: 1px solid rgba(255, 250, 240, 0.7);
+      border: 1px solid rgba(251, 242, 223, 0.72);
     }
 
     .farm-window::after {
@@ -162,7 +162,7 @@
       bottom: 18px;
       padding: 10px 14px;
       border-radius: 999px;
-      background: rgba(255, 250, 240, 0.8);
+      background: rgba(251, 242, 223, 0.82);
       color: var(--green);
       font-size: 0.88rem;
       letter-spacing: 0.08em;
@@ -212,7 +212,7 @@
       border: 1px solid var(--line);
       padding: 8px 12px;
       border-radius: 999px;
-      background: rgba(255, 250, 240, 0.6);
+      background: rgba(251, 242, 223, 0.64);
       font-size: 0.95rem;
     }
 
@@ -275,7 +275,7 @@
     table {
       border-collapse: collapse;
       width: 100%;
-      background: rgba(255, 250, 240, 0.72);
+      background: rgba(251, 242, 223, 0.76);
     }
 
     th,
@@ -342,7 +342,7 @@
       white-space: pre-wrap;
       font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
       font-size: 0.92rem;
-      background: rgba(255, 250, 240, 0.8);
+      background: rgba(251, 242, 223, 0.82);
       border: 1px solid var(--line);
       padding: 18px;
       border-radius: 18px;


### PR DESCRIPTION
## Summary
- Reduce the brightness of the regenerative farm page background
- Lower the radial glow opacity and shift the base gradient toward warmer parchment tones
- Soften hardcoded cream surfaces for cards, nav pills, table backing, and labels

## Validation
- `npm test`
- `git diff --check`
- Playwright render metrics at 1280, 390, 344, and 320px with no horizontal overflow
