### PR TITLE
[codex] Add microgreens farm pilot research

### DIFF
--- a/regenerative-farm/index.html
+++ b/regenerative-farm/index.html
@@ -691,6 +691,7 @@
     <div class="wrap">
       <a href="#vision">Vision</a>
       <a href="#research">Research</a>
+      <a href="#microgreens">Microgreens Pilot</a>
       <a href="#land">Land Leads</a>
       <a href="#land-reality">Land Reality</a>
       <a href="#areas">Target Areas</a>
@@ -730,6 +731,7 @@
             <li>Visit existing farms and ask what they would do if starting now.</li>
             <li>Find a lease, incubator plot, partnership, or retreat-property host.</li>
             <li>Run a 12-month pilot before committing to major debt.</li>
+            <li>Test microgreens as the first low-land food business.</li>
           </ol>
         </article>
       </div>
@@ -765,6 +767,75 @@
             farm, retreat, and education project in San Diego County or nearby.
           </p>
         </article>
+      </div>
+    </section>
+
+    <section id="microgreens">
+      <div class="wrap">
+        <h2>Microgreens as the First Farm Pilot</h2>
+        <p class="research-note">
+          Microgreens could be the cleanest way to begin before land ownership: small
+          footprint, fast crop cycles, local food story, and a realistic bridge into
+          restaurants, wellness circles, farmers markets, CSA boxes, and workshops.
+        </p>
+
+        <div class="grid three">
+          <article class="card">
+            <h3>Why it fits</h3>
+            <p>
+              A microgreens setup can start indoors or in a simple controlled environment,
+              which means the farm can begin learning production, packaging, delivery,
+              pricing, buyer conversations, and food safety without first solving acreage.
+            </p>
+            <ul>
+              <li>Fast feedback from 1-3 week crop cycles.</li>
+              <li>Low land need compared with field production.</li>
+              <li>Good story for health, family, chefs, and local food.</li>
+              <li>Can become a workshop, school, or subscription product later.</li>
+            </ul>
+          </article>
+
+          <article class="card">
+            <h3>90-day test</h3>
+            <p>
+              Start with a tiny production sprint instead of a full brand launch. Grow a
+              few reliable crops, track every tray, and sell or sample only after the food
+              safety workflow is repeatable.
+            </p>
+            <ul>
+              <li>Weeks 1-2: choose crops, shelves, trays, lights, water, sanitation, and records.</li>
+              <li>Weeks 3-6: run test trays and document yield, labor, failures, and shelf life.</li>
+              <li>Weeks 7-10: sample with chefs, neighbors, wellness contacts, and small buyers.</li>
+              <li>Weeks 11-12: decide whether to repeat, pause, or scale carefully.</li>
+            </ul>
+          </article>
+
+          <article class="card">
+            <h3>Rules before selling</h3>
+            <p>
+              Treat microgreens as produce, not a hobby jar project. California produce
+              rules, buyer requirements, packaging, labeling, traceability, and sanitation
+              should be understood before selling to restaurants, markets, or institutions.
+            </p>
+            <ul>
+              <li>Keep microgreens separate from sprouts in planning and marketing.</li>
+              <li>Use clean water, sanitized tools, clean harvest containers, and lot records.</li>
+              <li>Confirm city, county, farmers market, CSA, and buyer requirements directly.</li>
+              <li>Avoid processed products until kitchen, labeling, and licensing rules are clear.</li>
+            </ul>
+          </article>
+        </div>
+
+        <div style="margin-top:18px;">
+          <article class="note-box">
+            <h2>Microgreens Decision</h2>
+            <p>
+              This is probably the best first product if the goal is momentum before land:
+              prove consistency, prove local demand, build a buyer list, and learn whether
+              the family actually enjoys daily crop operations before taking on farm debt.
+            </p>
+          </article>
+        </div>
       </div>
     </section>
 
@@ -1309,6 +1380,7 @@ Thomas</div>
             <li>Visit at least five local models before choosing land.</li>
             <li>Build a spreadsheet of leads, dates, responses, next steps, and follow-ups.</li>
             <li>Draft a 12-month pilot that could work before owning land.</li>
+            <li>Run a 90-day microgreens pilot to test production discipline, local buyers, food safety, and subscription demand.</li>
             <li>Compare San Diego County with South Dakota, Tennessee, Italy, Baja, Kansas, Minnesota, Nebraska, and Iowa before narrowing the land search.</li>
             <li>Classify every incentive as relocation-only, farm finance, land-access support, cost share, or actual grant before planning around it.</li>
           </ol>
@@ -1385,6 +1457,12 @@ Thomas</div>
             <li><a href="https://www.theagrarianinstitute.org/">The Agrarian Institute</a></li>
             <li><a href="https://sagemountainfarm.com/">Sage Mountain Farm</a></li>
             <li><a href="https://www.goodneighborgardens.com/">Good Neighbor Gardens</a></li>
+            <li><a href="https://extension.missouri.edu/publications/g693">MU Extension: Microgreens Planning Budget</a></li>
+            <li><a href="https://extension.psu.edu/business-planning-for-your-microgreens-operation/">Penn State Extension: Business Planning for Microgreens</a></li>
+            <li><a href="https://extension.psu.edu/growing-microgreens/">Penn State Extension: Growing Microgreens</a></li>
+            <li><a href="https://ucanr.edu/site/agriculture-ombudsperson/selling-locally-grown-produce">UC ANR: Selling Locally Grown Produce</a></li>
+            <li><a href="https://www.cdfa.ca.gov/producesafety/about.html">CDFA Produce Safety Program</a></li>
+            <li><a href="https://utia.tennessee.edu/publications/wp-content/uploads/sites/269/2024/11/W1261.pdf">UT Extension: Regulatory Considerations for Sprouts, Microgreens and Baby Greens</a></li>
             <li><a href="https://sdgoed.com/program/beginning-farmer-bond-program/">South Dakota Beginning Farmer Bond Program</a></li>
             <li><a href="https://danr.sd.gov/AboutDANR/ProducerResources.aspx">South Dakota DANR producer resources</a></li>
             <li><a href="https://www.ismea.it/Startup/GenerazioneTerra">ISMEA Generazione Terra</a></li>

--- a/tests/homepage-copy.test.js
+++ b/tests/homepage-copy.test.js
@@ -49,6 +49,17 @@ describe('homepage personal positioning', () => {
     expect(trackerHtml).toContain('Classify every incentive as relocation-only');
   });
 
+  it('tracks microgreens as a first farm pilot', async () => {
+    const trackerHtml = await readFile('regenerative-farm/index.html', 'utf8');
+
+    expect(trackerHtml).toContain('Microgreens as the First Farm Pilot');
+    expect(trackerHtml).toContain('90-day microgreens pilot');
+    expect(trackerHtml).toContain('Keep microgreens separate from sprouts');
+    expect(trackerHtml).toContain('MU Extension: Microgreens Planning Budget');
+    expect(trackerHtml).toContain('CDFA Produce Safety Program');
+    expect(trackerHtml).toContain('UT Extension: Regulatory Considerations for Sprouts, Microgreens and Baby Greens');
+  });
+
   it('centers incomplete Command Central link rows', async () => {
     const css = await readFile('style.css', 'utf8');
 


### PR DESCRIPTION
## Summary
- Add microgreens as the first low-land food business pilot for the regenerative farm tracker
- Include a 90-day test plan, food-safety cautions, buyer-development framing, and next-step checklist item
- Add extension and official produce-safety sources for microgreens planning and selling produce
- Add a regression test for the new microgreens tracker content

## Validation
- `npm test`
- `git diff --check`
- Playwright render metrics at 1280, 390, 344, and 320px with no horizontal overflow
