### PR TITLE
[codex] Add MAKE Projects farm resource

### DIFF
--- a/regenerative-farm/index.html
+++ b/regenerative-farm/index.html
@@ -918,7 +918,7 @@
               <tr>
                 <td data-label="Lead">
                   <strong>Existing farms</strong>
-                  <small>Sand n' Straw, Coastal Roots, Agrarian Institute, Sage Mountain, Good Neighbor Gardens.</small>
+                  <small>Sand n' Straw, Coastal Roots, MAKE Projects, Agrarian Institute, Sage Mountain, Good Neighbor Gardens.</small>
                 </td>
                 <td data-label="Why it matters">
                   Models to visit before choosing land. These farms can teach real economics,
@@ -1220,6 +1220,13 @@
             </p>
           </article>
           <article class="card">
+            <h3><a href="https://www.sdmake.org/">MAKE Projects</a></h3>
+            <p>
+              San Diego farm, cafe, and social enterprise model with a one-acre urban farm,
+              CSA, field trips, public farm Saturdays, and refugee/immigrant workforce training.
+            </p>
+          </article>
+          <article class="card">
             <h3><a href="https://www.theagrarianinstitute.org/">The Agrarian Institute</a></h3>
             <p>
               Bonsall education farm model for organic produce, health education, land care,
@@ -1454,6 +1461,7 @@ Thomas</div>
             <li><a href="https://www.sandiegocounty.gov/content/sdc/pds/advance/uaiz.html">County Urban Agriculture Incentive Zone</a></li>
             <li><a href="https://www.sandnstraw.com/">Sand n' Straw Community Farm</a></li>
             <li><a href="https://coastalrootsfarm.org/">Coastal Roots Farm</a></li>
+            <li><a href="https://www.sdmake.org/">MAKE Projects</a></li>
             <li><a href="https://www.theagrarianinstitute.org/">The Agrarian Institute</a></li>
             <li><a href="https://sagemountainfarm.com/">Sage Mountain Farm</a></li>
             <li><a href="https://www.goodneighborgardens.com/">Good Neighbor Gardens</a></li>

--- a/tests/homepage-copy.test.js
+++ b/tests/homepage-copy.test.js
@@ -25,6 +25,8 @@ describe('homepage personal positioning', () => {
     expect(trackerHtml).toContain('Project New Village');
     expect(trackerHtml).toContain('RCD incubator plots');
     expect(trackerHtml).toContain('Local Models to Visit');
+    expect(trackerHtml).toContain('https://www.sdmake.org/');
+    expect(trackerHtml).toContain('MAKE Projects');
   });
 
   it('keeps the regenerative farm page compact on narrow displays', async () => {


### PR DESCRIPTION
## What changed
- Added MAKE Projects / SDMAKE to the regenerative farm tracker as a San Diego local model to visit.
- Added the SDMAKE URL to the source list.
- Added test coverage so the farm tracker keeps the MAKE Projects resource.

## Why
MAKE Projects is a relevant San Diego farm/cafe/social enterprise model with an urban farm, CSA, public farm days, field trips, and workforce/community impact.

## Validation
- `npm test -- tests/homepage-copy.test.js`
- `git diff --check`