### PR TITLE
[codex] Add California Farm & Garden resource

### DIFF
--- a/regenerative-farm/index.html
+++ b/regenerative-farm/index.html
@@ -918,7 +918,7 @@
               <tr>
                 <td data-label="Lead">
                   <strong>Existing farms</strong>
-                  <small>Sand n' Straw, Coastal Roots, MAKE Projects, Agrarian Institute, Sage Mountain, Good Neighbor Gardens.</small>
+                  <small>Sand n' Straw, Coastal Roots, MAKE Projects, Agrarian Institute, Sage Mountain, Good Neighbor Gardens, CA Farm & Garden.</small>
                 </td>
                 <td data-label="Why it matters">
                   Models to visit before choosing land. These farms can teach real economics,
@@ -1248,6 +1248,13 @@
             </p>
           </article>
           <article class="card">
+            <h3><a href="https://cafarmandgarden.com/">California Farm & Garden</a></h3>
+            <p>
+              Southern California urban farm and garden service model for design, installation,
+              maintenance, coaching, and production-focused edible landscapes.
+            </p>
+          </article>
+          <article class="card">
             <h3>Visit Question</h3>
             <p>
               Do not lead by asking for land. Ask: "What would you do if you were starting
@@ -1465,6 +1472,7 @@ Thomas</div>
             <li><a href="https://www.theagrarianinstitute.org/">The Agrarian Institute</a></li>
             <li><a href="https://sagemountainfarm.com/">Sage Mountain Farm</a></li>
             <li><a href="https://www.goodneighborgardens.com/">Good Neighbor Gardens</a></li>
+            <li><a href="https://cafarmandgarden.com/">California Farm & Garden</a></li>
             <li><a href="https://extension.missouri.edu/publications/g693">MU Extension: Microgreens Planning Budget</a></li>
             <li><a href="https://extension.psu.edu/business-planning-for-your-microgreens-operation/">Penn State Extension: Business Planning for Microgreens</a></li>
             <li><a href="https://extension.psu.edu/growing-microgreens/">Penn State Extension: Growing Microgreens</a></li>

--- a/tests/homepage-copy.test.js
+++ b/tests/homepage-copy.test.js
@@ -27,6 +27,8 @@ describe('homepage personal positioning', () => {
     expect(trackerHtml).toContain('Local Models to Visit');
     expect(trackerHtml).toContain('https://www.sdmake.org/');
     expect(trackerHtml).toContain('MAKE Projects');
+    expect(trackerHtml).toContain('https://cafarmandgarden.com/');
+    expect(trackerHtml).toContain('California Farm & Garden');
   });
 
   it('keeps the regenerative farm page compact on narrow displays', async () => {


### PR DESCRIPTION
## What changed
- Added California Farm & Garden to the regenerative farm tracker as a Southern California urban farm/garden service model.
- Added the link to the source list.
- Added test coverage so the tracker keeps the CA Farm & Garden resource.

## Why
California Farm & Garden is relevant to the farm tracker as a practical urban edible-landscape business and coaching model for design, installation, maintenance, and production-focused garden work.

## Validation
- `npm test -- tests/homepage-copy.test.js`
- `git diff --check`