### PR TITLE
[codex] Add family work-trade farm path

### DIFF
--- a/regenerative-farm/index.html
+++ b/regenerative-farm/index.html
@@ -696,6 +696,7 @@
       <a href="#land-reality">Land Reality</a>
       <a href="#areas">Target Areas</a>
       <a href="#relocation-research">Relocation Research</a>
+      <a href="#family-worktrade">Work-Trade</a>
       <a href="#farm-models">Farm Models</a>
       <a href="#outreach">Outreach</a>
       <a href="#retreats">Retreats</a>
@@ -1201,6 +1202,163 @@
       </div>
     </section>
 
+    <section id="family-worktrade">
+      <div class="wrap">
+        <h2>Family Work-Trade + Caretaker Path</h2>
+        <p class="research-note">
+          For Thomas, partner, and a 2-year-old, the better near-term search is not a generic
+          farm job. Look for family-friendly work-trade, caretaker housing, homestead community,
+          or farm apprenticeship situations with real infrastructure, clear work hours, and hosts
+          who explicitly welcome toddlers.
+        </p>
+
+        <div class="grid three program-list">
+          <article class="card">
+            <span class="program-type">Best farm-learning path</span>
+            <h3><a href="https://wwoof.net/howitworks/">WWOOF</a></h3>
+            <p>
+              Best first platform for organic and regenerative farm learning. Hosts typically
+              provide accommodation and meals in exchange for farm help and daily-life learning.
+              WWOOF explicitly allows families, though each host must still be screened for a
+              toddler-safe setup.
+            </p>
+            <ul>
+              <li>Message first: the Julian farm-to-table camp/conference listing because it is near San Diego and welcomes couples/families.</li>
+              <li>Also watch: LA-edge permaculture homestead, Kern Family Farm, and Grass Valley organic family farm listings.</li>
+            </ul>
+          </article>
+
+          <article class="card">
+            <span class="program-type">Best stability path</span>
+            <h3><a href="https://www.ranchwork.com/jcategory/ranch-jobs-with-housing/">RanchWork</a></h3>
+            <p>
+              A paid caretaker, ranch hand, property manager, or ranch couple role with housing
+              may be more stable than pure work-trade. This is especially important with a
+              toddler because housing, cashflow, and responsibilities need to be concrete.
+            </p>
+            <ul>
+              <li>Search: couple housing, caretaker housing California, ranch manager housing, Julian ranch caretaker, Valley Center ranch housing.</li>
+              <li>Watch Southern California listings weekly; past roles show up around Julian, San Diego County, Yucca Valley, Murrieta, Gaviota, Tehachapi, and Valley Center.</li>
+            </ul>
+          </article>
+
+          <article class="card">
+            <span class="program-type">California farm leads</span>
+            <h3><a href="https://caff.org/jobs/">CAFF Jobs + Farm Bureau</a></h3>
+            <p>
+              CAFF is the serious California agriculture job, internship, and land-opportunity
+              board. Pair it with San Diego County Farm Bureau classifieds for local owner,
+              ranch, lease, and North County farm leads.
+            </p>
+            <ul>
+              <li>Best fit: real California agriculture opportunities, internships, land leads, and local owners.</li>
+              <li>Search local zones: Valley Center, Pauma, Ramona, Julian, North County, and inland San Diego.</li>
+            </ul>
+          </article>
+
+          <article class="card">
+            <span class="program-type">Worldwide work-trade</span>
+            <h3><a href="https://www.workaway.info/en/hosttype/farm">Workaway</a></h3>
+            <p>
+              Good for farm, retreat center, eco-village, childcare, music, tech, web, building,
+              guesthouse, and community projects. Stronger than a narrow farm search if the
+              family wants to test the retreat and community side too.
+            </p>
+            <ul>
+              <li>Search: farm, retreat center, family friendly, permaculture, homestead, music, community, eco village.</li>
+              <li>Use the family angle as part of the pitch, not a hidden complication.</li>
+            </ul>
+          </article>
+
+          <article class="card">
+            <span class="program-type">Eco-village / retreat path</span>
+            <h3><a href="https://www.worldpackers.com/search/type_eco_village">Worldpackers</a></h3>
+            <p>
+              Useful for eco-villages, retreats, and land-based communities in the USA, Mexico,
+              Costa Rica, Europe, and beyond. Better for the music, retreat, nature, and
+              community direction than for strict farm production.
+            </p>
+            <ul>
+              <li>Search: eco village, permaculture, retreat center, family friendly, natural building, community.</li>
+              <li>Screen hard for housing quality, medical access, roads, potable water, and child safety.</li>
+            </ul>
+          </article>
+
+          <article class="card">
+            <span class="program-type">Long-term village path</span>
+            <h3><a href="https://www.ic.org/">Foundation for Intentional Community</a></h3>
+            <p>
+              Best for the co-raising children, land stewardship, shared meals, regenerative
+              living, and village direction. This is a longer-term search for communities where
+              a farm/retreat project could grow inside or near an existing land-based group.
+            </p>
+            <ul>
+              <li>Look for family-based homestead communities, land stewardship, creative income, and child-friendly culture.</li>
+              <li>Do not skip governance, conflict, income expectations, and visitor/residency rules.</li>
+            </ul>
+          </article>
+        </div>
+
+        <div class="grid two" style="margin-top:18px;">
+          <article class="note-box">
+            <h2>Southern California Shortlist</h2>
+            <ol>
+              <li>Julian WWOOF farm-to-table camp/conference center: closest first message because couples and families are welcome.</li>
+              <li>RanchWork Southern California housing jobs: best chance of paid housing plus stability.</li>
+              <li>San Diego County Farm Bureau classifieds: local owners and North County farm/ranch leads.</li>
+              <li>CAFF farm jobs and land opportunities: serious California agriculture path.</li>
+              <li>Los Angeles edge permaculture homestead: possible short urban-adjacent trial.</li>
+              <li>Flip Flop Ranch in Lucerne Valley: useful as a low-commitment family farm-stay test.</li>
+            </ol>
+          </article>
+
+          <article class="note-box">
+            <h2>Toddler Safety Filter</h2>
+            <p>
+              Avoid listings with rustic camping only, unreliable water, unfinished housing,
+              vague schedules, chaos language, or "we are just getting started" energy.
+            </p>
+            <ul>
+              <li>Minimum: safe sleeping space, bathroom, kitchen, potable water, shade/heat plan, emergency access, and explicit toddler approval.</li>
+              <li>Best trial: 2 weeks to 1 month near San Diego before a 2-3 month stay farther away.</li>
+              <li>Best path: trial farm stay, family-friendly work-trade, paid caretaker housing, then land/project decisions.</li>
+            </ul>
+          </article>
+        </div>
+
+        <div class="grid two" style="margin-top:18px;">
+          <article class="card">
+            <h2>Worldwide Regions to Watch</h2>
+            <ul>
+              <li>Mexico / Baja / mainland Mexico: close, lower cost, retreat/farm/community overlap.</li>
+              <li>Costa Rica / Guatemala / Colombia: permaculture, retreat, eco-lodge, and farm-stay culture.</li>
+              <li>Portugal / Spain / Italy: permaculture, eco-villages, rural renewal, and seasonal learning.</li>
+              <li>France / Germany / UK / Ireland: formal WWOOF/Workaway culture, but visas and costs matter.</li>
+              <li>New Zealand / Australia / Canada: strong farm-stay culture, but distance, seasons, and work authorization matter.</li>
+            </ul>
+          </article>
+
+          <article class="card">
+            <h2>Host Message Template</h2>
+            <div class="contact-script">Subject: Small family looking for farm/homestead work-live exchange
+
+Hi [Name],
+
+My name is Thomas. My partner, our 2-year-old, and I are looking for a family-friendly farm or homestead situation where we can live, learn, contribute, and possibly stay longer-term if it is a good fit.
+
+I have experience with web/tech, audio/video, events, basic hands-on work, and I am very interested in regenerative farming, homesteading, natural building, and community systems. My partner has a background in music facilitation and is great with children, groups, and community care.
+
+Because we have a toddler, we are looking for a safe and clear arrangement: reliable sleeping space, bathroom/kitchen access, potable water, and agreed work expectations. We are happy to help, but we want to make sure the setup is genuinely family-friendly.
+
+Are you currently open to hosting a couple with a 2-year-old? If so, what kind of housing, schedule, food arrangement, and length of stay would make sense?
+
+Thank you,
+Thomas</div>
+          </article>
+        </div>
+      </div>
+    </section>
+
     <section id="farm-models">
       <div class="wrap">
         <h2>Local Models to Visit</h2>
@@ -1492,6 +1650,21 @@ Thomas</div>
             <li><a href="https://nextgen.nebraska.gov/">Nebraska NextGen Beginning Farmer Program</a></li>
             <li><a href="https://opportunityiowa.gov/business/small-business-entrepreneurs/beginning-farmers">Iowa beginning farmer programs</a></li>
             <li><a href="https://www.fsa.usda.gov/resources/beginning-farmers-and-ranchers-loans">USDA FSA Beginning Farmers and Ranchers Loans</a></li>
+            <li><a href="https://wwoof.net/howitworks/">WWOOF: How it works</a></li>
+            <li><a href="https://wwoof.net/news/how-to-volunteer-on-a-farm-with-your-children-through-wwoof-%F0%9F%90%A3/">WWOOF: Volunteer with children</a></li>
+            <li><a href="https://wwoofusa.org/en/host/24842">WWOOF USA: Julian farm-to-table camp/conference center</a></li>
+            <li><a href="https://wwoofusa.org/en/host/25196">WWOOF USA: LA-edge permaculture homestead</a></li>
+            <li><a href="https://www.kernfamilyfarm.com/work-with-us">Kern Family Farm: Work With Us</a></li>
+            <li><a href="https://wwoofusa.org/en/host/24776">WWOOF USA: Grass Valley organic family farm</a></li>
+            <li><a href="https://www.ranchwork.com/jcategory/ranch-jobs-with-housing/">RanchWork: Ranch jobs with housing</a></li>
+            <li><a href="https://www.ranchwork.com/ptags/southern-california-ranch-jobs/">RanchWork: Southern California ranch jobs</a></li>
+            <li><a href="https://caff.org/jobs/">CAFF: Find a Farm Job</a></li>
+            <li><a href="https://www.workaway.info/en/hosttype/farm">Workaway: Farmstays</a></li>
+            <li><a href="https://www.workaway.info/en/info/traveller/families">Workaway: Traveling families</a></li>
+            <li><a href="https://www.worldpackers.com/search/type_eco_village">Worldpackers: Eco-village opportunities</a></li>
+            <li><a href="https://www.ic.org/">Foundation for Intentional Community</a></li>
+            <li><a href="https://www.ic.org/advert/northern-california-family-based-homestead-community/">FIC: Northern California family-based homestead community</a></li>
+            <li><a href="https://flipflopranch.com/">Flip Flop Ranch</a></li>
           </ul>
         </article>
       </div>

--- a/tests/homepage-copy.test.js
+++ b/tests/homepage-copy.test.js
@@ -53,6 +53,21 @@ describe('homepage personal positioning', () => {
     expect(trackerHtml).toContain('Classify every incentive as relocation-only');
   });
 
+  it('tracks family-friendly farm work-trade and caretaker paths', async () => {
+    const trackerHtml = await readFile('regenerative-farm/index.html', 'utf8');
+
+    expect(trackerHtml).toContain('Family Work-Trade + Caretaker Path');
+    expect(trackerHtml).toContain('WWOOF');
+    expect(trackerHtml).toContain('RanchWork');
+    expect(trackerHtml).toContain('CAFF Jobs + Farm Bureau');
+    expect(trackerHtml).toContain('Workaway');
+    expect(trackerHtml).toContain('Worldpackers');
+    expect(trackerHtml).toContain('Foundation for Intentional Community');
+    expect(trackerHtml).toContain('Toddler Safety Filter');
+    expect(trackerHtml).toContain('Julian WWOOF farm-to-table camp/conference center');
+    expect(trackerHtml).toContain('https://www.ranchwork.com/jcategory/ranch-jobs-with-housing/');
+  });
+
   it('tracks microgreens as a first farm pilot', async () => {
     const trackerHtml = await readFile('regenerative-farm/index.html', 'utf8');
 


### PR DESCRIPTION
## What changed
- Added a new Family Work-Trade + Caretaker Path section to the regenerative farm tracker.
- Covered WWOOF, RanchWork, CAFF, Workaway, Worldpackers, and intentional-community paths.
- Added a Southern California shortlist, toddler safety filter, worldwide regions to watch, and a host message template.
- Added the supporting source links and regression coverage.

## Why
The farm path for a small family with a toddler should prioritize safe housing, clear work expectations, and trial stays before buying land. This reframes the search around family-friendly work-trade, caretaker housing, and community apprenticeship options.

## Validation
- `npm test -- tests/homepage-copy.test.js`
- `git diff --check`