### PR TITLE
[codex] Add Tantra discovery reference

### DIFF
--- a/tantra/app.js
+++ b/tantra/app.js
@@ -52,6 +52,12 @@ export const practiceReferences = Object.freeze([
     url: 'https://xhamster.com/videos/lingam-massage-will-relax-him-9419776',
     note: 'External adult practice reference. Open only from the approved private room.',
   },
+  {
+    title: 'Discovering Tantra reference',
+    source: 'xHamster',
+    url: 'https://xhamster.com/videos/discovering-tantra-xhZY9Ev',
+    note: 'External adult practice reference. Open only from the approved private room.',
+  },
 ]);
 
 export function normalizeAlias(alias) {

--- a/tests/tantra-access.test.js
+++ b/tests/tantra-access.test.js
@@ -49,16 +49,25 @@ describe('tantra approval gate', () => {
   it('keeps external adult references inside the approval-only room', async () => {
     const html = await readFile('tantra/index.html', 'utf8');
     const homepage = await readFile('index.html', 'utf8');
-    const url = 'https://xhamster.com/videos/lingam-massage-will-relax-him-9419776';
+    const urls = [
+      'https://xhamster.com/videos/lingam-massage-will-relax-him-9419776',
+      'https://xhamster.com/videos/discovering-tantra-xhZY9Ev',
+    ];
 
     expect(practiceReferences).toEqual([
       expect.objectContaining({
         title: 'Lingam massage reference',
-        url,
+        url: urls[0],
+      }),
+      expect.objectContaining({
+        title: 'Discovering Tantra reference',
+        url: urls[1],
       }),
     ]);
     expect(html).toContain('id="tantra-reference-list"');
-    expect(homepage).not.toContain(url);
+    urls.forEach((url) => {
+      expect(homepage).not.toContain(url);
+    });
   });
 
   it('links the approval-only section from the homepage', async () => {


### PR DESCRIPTION
## Summary

Adds the second approved-only external Tantra practice reference.

## What changed

- Adds the `Discovering Tantra reference` URL to the Tantra room's private practice references list.
- Updates tests so both adult external links are covered and stay out of the homepage.

## Validation

- `node --check tantra/app.js`
- `npm test -- tests/tantra-access.test.js tests/homepage-copy.test.js`