### PR TITLE
feat: add synced family recipe book

### DIFF
--- a/clean-meals/index.html
+++ b/clean-meals/index.html
@@ -103,6 +103,7 @@
     Simple, organic, and picky-friendly meals that feel good to eat
     and easy to love.
   </p>
+  <p><a href="../recipe-book/">Open the family recipe book →</a></p>
 </header>
 
 <section>

--- a/e2e/recipe-book.spec.js
+++ b/e2e/recipe-book.spec.js
@@ -1,0 +1,130 @@
+import { expect, test } from '@playwright/test';
+
+test('recipe workflow supports links, ingredients, and meal-planner handoff', async ({ page }) => {
+  const id = `browser-${Date.now()}`;
+  await page.goto(`/recipe-book/?book=${id}&list=${id}`);
+
+  await page.locator('#recipe-title').fill('Weeknight lemon chicken');
+  await page
+    .locator('#recipe-url')
+    .fill('https://www.allrecipes.com/recipe/242352/greek-lemon-chicken-and-potatoes/');
+  await page.locator('#recipe-description').fill('Realistic family dinner test');
+  await page.locator('#recipe-servings').fill('4');
+  await page
+    .locator('#recipe-ingredients')
+    .fill('1 1/2 lb | chicken thighs | Meat\n2 | lemons | Produce');
+  await page
+    .locator('#recipe-directions')
+    .fill('Heat oven to 425°F.\nCook chicken to 165°F.');
+  await page.getByRole('button', { name: 'Save recipe' }).click();
+  await expect(page.locator('#recipe-sync-status')).toContainText('Saved');
+
+  const card = page.locator('[data-recipe-id]').filter({ hasText: 'Weeknight lemon chicken' });
+  await expect(card).toBeVisible();
+  await expect(card).toContainText('1 1/2 lb chicken thighs');
+  await expect(card).toContainText('Heat oven to 425°F.');
+
+  const planUrl = await card.getByRole('link', { name: 'Plan meal' }).getAttribute('href');
+  const mealPage = await page.context().newPage();
+  await mealPage.goto(planUrl);
+  await expect(mealPage.locator('#meal-menu')).toHaveValue('Weeknight lemon chicken');
+  await mealPage.getByRole('button', { name: 'Save meal' }).click();
+  const plannedMeal = mealPage
+    .locator('.meal-card')
+    .filter({ hasText: 'Weeknight lemon chicken' })
+    .first();
+  await expect(plannedMeal.getByRole('link', { name: 'View recipe' })).toBeVisible();
+  mealPage.on('dialog', (dialog) => dialog.accept());
+  await plannedMeal.getByRole('button', { name: /Delete/ }).click();
+  await mealPage.close();
+
+  page.on('dialog', (dialog) => dialog.accept());
+  await card.getByRole('button', { name: 'Delete' }).click();
+  await expect(card).toHaveCount(0);
+});
+
+test('real relay syncs a recipe and its shopping items across browser contexts', async ({
+  browser,
+}) => {
+  test.skip(process.env.REAL_SYNC !== '1', 'Run with REAL_SYNC=1 for live relay verification.');
+  test.setTimeout(90_000);
+
+  const id = `sync-${Date.now()}-${Math.random().toString(16).slice(2, 8)}`;
+  const sharedPath = `/recipe-book/?book=${id}&list=${id}`;
+  const firstContext = await browser.newContext();
+  const secondContext = await browser.newContext();
+  const firstPage = await firstContext.newPage();
+  const secondPage = await secondContext.newPage();
+
+  try {
+    await firstPage.goto(sharedPath);
+    await firstPage.locator('#recipe-title').fill('Relay test lemon chicken');
+    await firstPage
+      .locator('#recipe-url')
+      .fill('https://www.allrecipes.com/recipe/242352/greek-lemon-chicken-and-potatoes/');
+    await firstPage
+      .locator('#recipe-ingredients')
+      .fill('1 1/2 lb | chicken thighs | Meat\n2 | lemons | Produce');
+    await firstPage
+      .locator('#recipe-directions')
+      .fill('Heat oven to 425°F.\nCook chicken to 165°F.');
+    await firstPage.getByRole('button', { name: 'Save recipe' }).click();
+    await expect(firstPage.locator('#recipe-sync-status')).toContainText('Saved', {
+      timeout: 20_000,
+    });
+    await expect(
+      firstPage.getByRole('heading', { name: 'Relay test lemon chicken' })
+    ).toBeVisible();
+    await firstPage.waitForTimeout(1_500);
+
+    await secondPage.goto(sharedPath);
+    const findSyncedCard = () =>
+      secondPage
+        .locator('[data-recipe-id]')
+        .filter({ hasText: 'Relay test lemon chicken' });
+    await expect
+      .poll(
+        async () => {
+          const count = await findSyncedCard().count();
+          if (!count) {
+            await secondPage.reload();
+            await secondPage.waitForTimeout(750);
+          }
+          return count;
+        },
+        { timeout: 40_000, intervals: [1_000, 2_000, 4_000] }
+      )
+      .toBeGreaterThan(0);
+    const syncedCard = findSyncedCard();
+    await syncedCard.getByRole('button', { name: 'Add ingredients' }).click();
+    await expect(secondPage.locator('#recipe-sync-status')).toContainText(
+      '2 ingredients added'
+    );
+
+    await firstPage.goto(`/shopping-list/?list=${id}`);
+    await expect(firstPage.getByText(/chicken thighs/i)).toBeVisible({ timeout: 20_000 });
+    await expect(firstPage.getByText(/lemons/i)).toBeVisible({ timeout: 20_000 });
+
+    await secondPage.goto(`/shopping-list/?list=${id}`);
+    await expect(secondPage.getByText(/chicken thighs/i)).toBeVisible({ timeout: 20_000 });
+    await expect(secondPage.getByText(/lemons/i)).toBeVisible({ timeout: 20_000 });
+
+    const deleteButtons = firstPage.getByRole('button', { name: 'Delete' });
+    while ((await deleteButtons.count()) > 0) {
+      await deleteButtons.first().click();
+      await firstPage.waitForTimeout(100);
+    }
+
+    firstPage.on('dialog', (dialog) => dialog.accept());
+    await firstPage.goto(sharedPath);
+    const recipeDelete = firstPage
+      .locator('[data-recipe-id]')
+      .filter({ hasText: 'Relay test lemon chicken' })
+      .getByRole('button', { name: 'Delete' });
+    await expect(recipeDelete).toBeVisible({ timeout: 20_000 });
+    await recipeDelete.click();
+  } finally {
+    await firstContext.close();
+    await secondContext.close();
+  }
+});

--- a/index.html
+++ b/index.html
@@ -155,6 +155,7 @@
       <a class="project-card" href="journal/">Journal & Content Lab</a>
       <a class="project-card" href="stagehand.html">Stagehand Life</a>
       <a class="project-card" href="meal-tracker/index.html">Meal Tracker</a>
+      <a class="project-card" href="recipe-book/index.html">Family Recipe Book</a>
       <a class="project-card" href="clean-meals/index.html">Clean & Nourishing Meals</a>
       <a class="project-card" href="shopping-list/index.html">Shopping List</a>
       <a class="project-card" href="regenerative-farm/index.html">Regenerative Farm Tracker</a>

--- a/meal-tracker/index.html
+++ b/meal-tracker/index.html
@@ -20,7 +20,11 @@
     <div class="container">
       <h1 class="handwritten">Meal Tracker</h1>
       <p class="tagline">Capture meals for the whole family in one place.</p>
-      <a href="../index.html" class="btn-primary">← Back to Home</a>
+      <div class="recipe-nav">
+        <a href="../index.html" class="btn-primary">← Back to Home</a>
+        <a href="../recipe-book/" class="btn-secondary">Recipe book</a>
+        <a href="../shopping-list/" class="btn-secondary">Shopping list</a>
+      </div>
     </div>
   </header>
 

--- a/meal-tracker/meal-tracker.js
+++ b/meal-tracker/meal-tracker.js
@@ -11,6 +11,9 @@ const cancelButton = document.getElementById('meal-cancel');
 const list = document.getElementById('meal-list');
 const emptyState = document.getElementById('meal-empty');
 const today = new Date().toISOString().split('T')[0];
+const query = new URLSearchParams(window.location.search);
+const linkedRecipeId = query.get('recipe') || '';
+const linkedBookId = query.get('book') || '';
 
 const entries = gun.get('meal-tracker').get('entries');
 const cache = new Map();
@@ -75,6 +78,15 @@ const renderMeals = () => {
     dateTag.textContent = formatDate(entry.date);
 
     meta.append(typeTag, dateTag);
+    if (entry.recipeId) {
+      const recipeLink = document.createElement('a');
+      recipeLink.className = 'meal-tag';
+      const params = new URLSearchParams();
+      if (entry.recipeBookId) params.set('book', entry.recipeBookId);
+      recipeLink.href = `../recipe-book/${params.size ? `?${params.toString()}` : ''}`;
+      recipeLink.textContent = 'View recipe';
+      meta.appendChild(recipeLink);
+    }
     header.append(title, meta);
 
     const actions = document.createElement('div');
@@ -150,6 +162,8 @@ entries.map().on((data, key) => {
     mealType: data.mealType,
     date: data.date,
     menu: data.menu,
+    recipeId: data.recipeId,
+    recipeBookId: data.recipeBookId,
     createdAt: data.createdAt,
   });
 
@@ -173,6 +187,8 @@ form.addEventListener('submit', (event) => {
       mealType,
       date,
       menu,
+      recipeId: existing?.recipeId || linkedRecipeId,
+      recipeBookId: existing?.recipeBookId || linkedBookId,
       createdAt: existing?.createdAt ?? Date.now(),
       updatedAt: Date.now(),
     });
@@ -185,6 +201,8 @@ form.addEventListener('submit', (event) => {
     mealType,
     date,
     menu,
+    recipeId: linkedRecipeId,
+    recipeBookId: linkedBookId,
     createdAt: Date.now(),
   });
 
@@ -193,6 +211,9 @@ form.addEventListener('submit', (event) => {
 
 if (!dateInput.value) {
   dateInput.value = today;
+}
+if (query.get('menu')) {
+  menuInput.value = query.get('menu');
 }
 
 cancelButton.addEventListener('click', () => {

--- a/playwright.config.cjs
+++ b/playwright.config.cjs
@@ -2,6 +2,7 @@
 const { defineConfig } = require('@playwright/test');
 const isTermux = Boolean(process.env.TERMUX_VERSION);
 const chromiumExecutablePath = '/data/data/com.termux/files/usr/bin/chromium-browser';
+const configuredExecutablePath = process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE;
 
 module.exports = defineConfig({
   testDir: '.',
@@ -11,7 +12,12 @@ module.exports = defineConfig({
   use: {
     baseURL: 'http://localhost:8000',
     headless: true,
-    launchOptions: isTermux
+    launchOptions: configuredExecutablePath
+      ? {
+          executablePath: configuredExecutablePath,
+          args: ['--no-sandbox', '--disable-dev-shm-usage']
+        }
+      : isTermux
       ? {
           executablePath: chromiumExecutablePath,
           args: ['--no-sandbox', '--disable-dev-shm-usage']

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -2,6 +2,7 @@ import { defineConfig } from '@playwright/test';
 
 const isTermux = Boolean(process.env.TERMUX_VERSION);
 const chromiumExecutablePath = '/data/data/com.termux/files/usr/bin/chromium-browser';
+const configuredExecutablePath = process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE;
 
 export default defineConfig({
   testDir: './e2e',
@@ -12,7 +13,12 @@ export default defineConfig({
   use: {
     baseURL: 'http://127.0.0.1:4173',
     headless: true,
-    launchOptions: isTermux
+    launchOptions: configuredExecutablePath
+      ? {
+          executablePath: configuredExecutablePath,
+          args: ['--no-sandbox', '--disable-dev-shm-usage']
+        }
+      : isTermux
       ? {
           executablePath: chromiumExecutablePath,
           args: ['--no-sandbox', '--disable-dev-shm-usage']

--- a/recipe-book/index.html
+++ b/recipe-book/index.html
@@ -1,0 +1,124 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="theme-color" content="#0b1d39">
+  <title>Recipe Book - Thomas Stephens</title>
+  <link rel="stylesheet" href="../style.css">
+  <link rel="shortcut icon" href="../favicon-16x16.png" type="image/x-icon">
+  <link rel="apple-touch-icon" href="../icons/pwa-icon-192.png">
+  <link rel="manifest" href="../manifest.webmanifest">
+  <link href="https://fonts.googleapis.com/css2?family=Caveat:wght@400;700&family=Quicksand:wght@400;700&display=swap" rel="stylesheet">
+  <script src="../pwa.js" defer></script>
+  <script defer src="/_vercel/analytics/script.js"></script>
+</head>
+<body>
+  <div id="starfield"></div>
+
+  <header class="hero fade-in">
+    <div class="container">
+      <h1 class="handwritten">Family Recipe Book</h1>
+      <p class="tagline">Keep useful recipe links, family directions, and grocery ingredients together.</p>
+      <div class="recipe-nav">
+        <a href="../index.html" class="btn-primary">← Home</a>
+        <a href="../meal-tracker/" class="btn-secondary">Meal tracker</a>
+        <a id="recipe-shopping-link" href="../shopping-list/" class="btn-secondary">Shopping list</a>
+      </div>
+    </div>
+  </header>
+
+  <section class="section card fade-in">
+    <div class="container">
+      <div class="section-header">
+        <h2>Save a recipe</h2>
+        <p>A title and link are enough. Add ingredients or directions whenever they are useful.</p>
+      </div>
+
+      <div class="tracker-grid">
+        <form class="tracker-form" id="recipe-form">
+          <h3 id="recipe-form-title">New recipe</h3>
+
+          <label for="recipe-title">Recipe title</label>
+          <input id="recipe-title" name="recipe-title" type="text" placeholder="Sheet-pan lemon chicken" required>
+
+          <label for="recipe-url">Recipe link</label>
+          <input id="recipe-url" name="recipe-url" type="url" placeholder="https://example.com/recipe">
+
+          <label for="recipe-description">Notes</label>
+          <textarea id="recipe-description" name="recipe-description" rows="3" placeholder="Why we saved it, substitutions, or who likes it"></textarea>
+
+          <div class="recipe-time-grid">
+            <div>
+              <label for="recipe-servings">Servings</label>
+              <input id="recipe-servings" name="recipe-servings" type="text" placeholder="4">
+            </div>
+            <div>
+              <label for="recipe-prep-time">Prep time</label>
+              <input id="recipe-prep-time" name="recipe-prep-time" type="text" placeholder="15 min">
+            </div>
+            <div>
+              <label for="recipe-cook-time">Cook time</label>
+              <input id="recipe-cook-time" name="recipe-cook-time" type="text" placeholder="30 min">
+            </div>
+          </div>
+
+          <label for="recipe-ingredients">Ingredients</label>
+          <textarea id="recipe-ingredients" name="recipe-ingredients" rows="7" placeholder="1 lb | chicken thighs | Meat&#10;2 | lemons | Produce&#10;Olive oil"></textarea>
+          <p class="tracker-note">One per line. Optional format: quantity | ingredient | category.</p>
+
+          <label for="recipe-directions">Directions</label>
+          <textarea id="recipe-directions" name="recipe-directions" rows="7" placeholder="Heat the oven to 425°F.&#10;Season the chicken.&#10;Roast until cooked through."></textarea>
+          <p class="tracker-note">One step per line.</p>
+
+          <button class="btn-primary" type="submit" id="recipe-submit">Save recipe</button>
+          <button class="btn-secondary" type="button" id="recipe-cancel" hidden>Cancel edit</button>
+        </form>
+
+        <div class="tracker-results">
+          <div class="section-header">
+            <h3>Saved recipes</h3>
+            <p class="tracker-note">Shared through the same relay pattern as the shopping list.</p>
+          </div>
+
+          <div class="shopping-sync-panel">
+            <label for="recipe-share-link">Family recipe-book link</label>
+            <div class="shopping-sync-row">
+              <input id="recipe-share-link" type="url" readonly aria-label="Current recipe book link">
+              <button class="shopping-action-btn" type="button" id="recipe-copy-link">Copy link</button>
+            </div>
+            <p class="tracker-note" id="recipe-sync-status" aria-live="polite">Connecting…</p>
+          </div>
+
+          <div class="tracker-filter">
+            <label for="recipe-search">Find a recipe</label>
+            <input id="recipe-search" type="search" placeholder="Search title, notes, or ingredients">
+          </div>
+
+          <p class="tracker-note" id="recipe-empty">No recipes yet. Save a favorite link or family recipe above.</p>
+          <ul class="meal-list" id="recipe-list" aria-live="polite"></ul>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <footer class="fade-in">
+    <div class="container">
+      <p class="handwritten">© 2026 Thomas Stephens | Save what works. Cook it again.</p>
+    </div>
+  </footer>
+
+  <script src="https://cdn.jsdelivr.net/npm/gun/gun.js" defer></script>
+  <script src="recipe-book.js" type="module" defer></script>
+  <script>
+    const starField = document.getElementById('starfield');
+    for (let i = 0; i < 80; i++) {
+      const star = document.createElement('div');
+      star.className = 'star';
+      star.style.top = Math.random() * 100 + 'vh';
+      star.style.left = Math.random() * 100 + 'vw';
+      starField.appendChild(star);
+    }
+  </script>
+</body>
+</html>

--- a/recipe-book/recipe-book.js
+++ b/recipe-book/recipe-book.js
@@ -1,0 +1,501 @@
+const RELAY_URL = 'https://gun-relay-3dvr.fly.dev/gun';
+const BOOK_PARAM = 'book';
+const LIST_PARAM = 'list';
+const BOOK_STORAGE_KEY = 'recipeBookId';
+const LIST_STORAGE_KEY = 'shoppingListId';
+
+const createSharedId = (prefix) =>
+  `${prefix}-${Date.now().toString(36)}-${Math.random().toString(16).slice(2, 8)}`;
+
+const normalizeSharedId = (value) => {
+  const id = String(value || '').trim();
+  return /^[a-zA-Z0-9_-]{1,100}$/.test(id) ? id : '';
+};
+
+const normalizeHttpUrl = (value) => {
+  const raw = String(value || '').trim();
+  if (!raw) return '';
+  try {
+    const url = new URL(raw);
+    return ['http:', 'https:'].includes(url.protocol) ? url.toString() : '';
+  } catch {
+    return '';
+  }
+};
+
+const readStorage = (windowRef, key) => {
+  try {
+    return windowRef?.localStorage?.getItem(key) || '';
+  } catch {
+    return '';
+  }
+};
+
+const writeStorage = (windowRef, key, value) => {
+  try {
+    windowRef?.localStorage?.setItem(key, value);
+  } catch {
+    // Share URLs remain the portable fallback when browser storage is unavailable.
+  }
+};
+
+const resolveSharedId = ({ windowRef, url, param, storageKey, prefix }) => {
+  const fromUrl = normalizeSharedId(url.searchParams.get(param));
+  if (fromUrl) {
+    writeStorage(windowRef, storageKey, fromUrl);
+    return fromUrl;
+  }
+
+  const id =
+    normalizeSharedId(readStorage(windowRef, storageKey)) || createSharedId(prefix);
+  writeStorage(windowRef, storageKey, id);
+  url.searchParams.set(param, id);
+  return id;
+};
+
+const safeJsonArray = (value) => {
+  if (Array.isArray(value)) {
+    return value;
+  }
+  if (!value) {
+    return [];
+  }
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+};
+
+const normalizeCategory = (value) => {
+  const category = String(value || '').trim();
+  const known = ['Produce', 'Pantry', 'Dairy', 'Meat', 'Frozen', 'Household', 'Other'];
+  return known.find((entry) => entry.toLowerCase() === category.toLowerCase()) || 'Other';
+};
+
+export const parseIngredientLines = (value) =>
+  String(value || '')
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const parts = line.split('|').map((part) => part.trim());
+      if (parts.length >= 3) {
+        return {
+          quantity: parts[0],
+          name: parts[1],
+          category: normalizeCategory(parts[2]),
+        };
+      }
+      if (parts.length === 2) {
+        return { quantity: parts[0], name: parts[1], category: 'Other' };
+      }
+      return { quantity: '', name: parts[0], category: 'Other' };
+    })
+    .filter((ingredient) => ingredient.name);
+
+export const formatIngredientLines = (ingredients) =>
+  safeJsonArray(ingredients)
+    .map(({ quantity = '', name = '', category = 'Other' }) => {
+      if (!quantity && normalizeCategory(category) === 'Other') {
+        return name;
+      }
+      return `${quantity} | ${name} | ${normalizeCategory(category)}`;
+    })
+    .join('\n');
+
+export const parseDirectionLines = (value) =>
+  String(value || '')
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+const putWithAcknowledgement = (node, value, timeoutMs = 8_000) =>
+  new Promise((resolve) => {
+    let finished = false;
+    const finish = (ack = {}) => {
+      if (finished) return;
+      finished = true;
+      clearTimeout(timeout);
+      resolve(ack);
+    };
+    const timeout = setTimeout(() => finish({ timeout: true }), timeoutMs);
+    node.put(value, finish);
+  });
+
+export const addIngredientsToShoppingList = async ({
+  gun,
+  listId,
+  recipe,
+  now = () => Date.now(),
+  random = () => Math.random(),
+}) => {
+  const ingredients = safeJsonArray(recipe.ingredients);
+  const root = gun.get('shopping-list').get(listId);
+  const entries = root.get('items');
+  const itemIndex = root.get('item-index');
+
+  const writes = ingredients.map(async (ingredient, index) => {
+    const timestamp = now();
+    const id = `${timestamp}-${index}-${random().toString(16).slice(2, 8)}`;
+    await putWithAcknowledgement(entries.get(id), {
+      name: ingredient.name,
+      quantity: ingredient.quantity || '',
+      category: normalizeCategory(ingredient.category),
+      neededBy: '',
+      store: '',
+      notes: `From recipe: ${recipe.title}`,
+      sourceRecipeId: recipe.id,
+      sourceRecipeTitle: recipe.title,
+      createdAt: timestamp,
+      purchased: false,
+    });
+    await putWithAcknowledgement(itemIndex, { [id]: true });
+    return id;
+  });
+  return Promise.all(writes);
+};
+
+export const initRecipeBook = ({
+  Gun: GunLib = globalThis.Gun,
+  document: documentRef = globalThis.document,
+  window: windowRef = documentRef?.defaultView ?? globalThis.window,
+} = {}) => {
+  if (!GunLib || !documentRef) {
+    return null;
+  }
+
+  const currentUrl = new URL(windowRef?.location?.href || 'https://example.com/recipe-book/');
+  const bookId = resolveSharedId({
+    windowRef,
+    url: currentUrl,
+    param: BOOK_PARAM,
+    storageKey: BOOK_STORAGE_KEY,
+    prefix: 'book',
+  });
+  const listId = resolveSharedId({
+    windowRef,
+    url: currentUrl,
+    param: LIST_PARAM,
+    storageKey: LIST_STORAGE_KEY,
+    prefix: 'list',
+  });
+
+  if (windowRef?.history?.replaceState) {
+    windowRef.history.replaceState({}, '', currentUrl.toString());
+  }
+
+  const gun = GunLib({ peers: [RELAY_URL], localStorage: true });
+  const bookRoot = gun.get('recipe-book').get(bookId);
+  const recipes = bookRoot.get('recipes');
+  const recipeIndex = bookRoot.get('recipe-index');
+  const cache = new Map();
+  const subscribedRecipes = new Set();
+
+  const form = documentRef.getElementById('recipe-form');
+  const formTitle = documentRef.getElementById('recipe-form-title');
+  const titleInput = documentRef.getElementById('recipe-title');
+  const urlInput = documentRef.getElementById('recipe-url');
+  const descriptionInput = documentRef.getElementById('recipe-description');
+  const servingsInput = documentRef.getElementById('recipe-servings');
+  const prepTimeInput = documentRef.getElementById('recipe-prep-time');
+  const cookTimeInput = documentRef.getElementById('recipe-cook-time');
+  const ingredientsInput = documentRef.getElementById('recipe-ingredients');
+  const directionsInput = documentRef.getElementById('recipe-directions');
+  const submitButton = documentRef.getElementById('recipe-submit');
+  const cancelButton = documentRef.getElementById('recipe-cancel');
+  const list = documentRef.getElementById('recipe-list');
+  const emptyState = documentRef.getElementById('recipe-empty');
+  const searchInput = documentRef.getElementById('recipe-search');
+  const shareInput = documentRef.getElementById('recipe-share-link');
+  const copyButton = documentRef.getElementById('recipe-copy-link');
+  const syncStatus = documentRef.getElementById('recipe-sync-status');
+  const shoppingLink = documentRef.getElementById('recipe-shopping-link');
+  let editingId = null;
+
+  const shareUrl = currentUrl.toString();
+  if (shareInput) {
+    shareInput.value = shareUrl;
+  }
+  if (shoppingLink) {
+    shoppingLink.href = `../shopping-list/?list=${encodeURIComponent(listId)}`;
+  }
+
+  const setStatus = (message) => {
+    if (syncStatus) {
+      syncStatus.textContent = message;
+    }
+  };
+
+  const resetForm = () => {
+    editingId = null;
+    form?.reset();
+    if (formTitle) formTitle.textContent = 'New recipe';
+    if (submitButton) submitButton.textContent = 'Save recipe';
+    if (cancelButton) cancelButton.hidden = true;
+  };
+
+  const setEditState = (recipe) => {
+    editingId = recipe?.id || null;
+    if (!recipe) {
+      resetForm();
+      return;
+    }
+
+    formTitle.textContent = 'Edit recipe';
+    submitButton.textContent = 'Save changes';
+    cancelButton.hidden = false;
+    titleInput.value = recipe.title || '';
+    urlInput.value = recipe.sourceUrl || '';
+    descriptionInput.value = recipe.description || '';
+    servingsInput.value = recipe.servings || '';
+    prepTimeInput.value = recipe.prepTime || '';
+    cookTimeInput.value = recipe.cookTime || '';
+    ingredientsInput.value = formatIngredientLines(recipe.ingredients);
+    directionsInput.value = safeJsonArray(recipe.directions).join('\n');
+    titleInput.focus();
+    form.scrollIntoView?.({ behavior: 'smooth', block: 'start' });
+  };
+
+  const renderRecipes = () => {
+    const query = searchInput?.value?.trim().toLowerCase() || '';
+    const items = Array.from(cache.values())
+      .filter((recipe) => recipe?.title)
+      .filter((recipe) => {
+        if (!query) return true;
+        const searchable = [
+          recipe.title,
+          recipe.description,
+          recipe.sourceUrl,
+          ...safeJsonArray(recipe.ingredients).map((ingredient) => ingredient.name),
+        ]
+          .join(' ')
+          .toLowerCase();
+        return searchable.includes(query);
+      })
+      .sort((a, b) => (b.updatedAt || b.createdAt || 0) - (a.updatedAt || a.createdAt || 0));
+
+    list.innerHTML = '';
+    emptyState.hidden = items.length > 0;
+
+    for (const recipe of items) {
+      const card = documentRef.createElement('li');
+      card.className = 'meal-card recipe-card';
+      card.dataset.recipeId = recipe.id;
+
+      const header = documentRef.createElement('div');
+      header.className = 'meal-card__header';
+      const title = documentRef.createElement('h4');
+      title.textContent = recipe.title;
+      const meta = documentRef.createElement('div');
+      meta.className = 'meal-meta';
+      for (const label of [recipe.servings && `${recipe.servings} servings`, recipe.prepTime && `Prep ${recipe.prepTime}`, recipe.cookTime && `Cook ${recipe.cookTime}`].filter(Boolean)) {
+        const tag = documentRef.createElement('span');
+        tag.className = 'meal-tag';
+        tag.textContent = label;
+        meta.appendChild(tag);
+      }
+      header.append(title, meta);
+      card.appendChild(header);
+
+      if (recipe.description) {
+        const description = documentRef.createElement('p');
+        description.textContent = recipe.description;
+        card.appendChild(description);
+      }
+
+      const ingredients = safeJsonArray(recipe.ingredients);
+      if (ingredients.length) {
+        const heading = documentRef.createElement('strong');
+        heading.textContent = 'Ingredients';
+        const ingredientList = documentRef.createElement('ul');
+        ingredientList.className = 'recipe-details';
+        for (const ingredient of ingredients) {
+          const row = documentRef.createElement('li');
+          row.textContent = [ingredient.quantity, ingredient.name].filter(Boolean).join(' ');
+          ingredientList.appendChild(row);
+        }
+        card.append(heading, ingredientList);
+      }
+
+      const directions = safeJsonArray(recipe.directions);
+      if (directions.length) {
+        const heading = documentRef.createElement('strong');
+        heading.textContent = 'Directions';
+        const directionList = documentRef.createElement('ol');
+        directionList.className = 'recipe-details';
+        for (const direction of directions) {
+          const row = documentRef.createElement('li');
+          row.textContent = direction;
+          directionList.appendChild(row);
+        }
+        card.append(heading, directionList);
+      }
+
+      const actions = documentRef.createElement('div');
+      actions.className = 'shopping-actions recipe-actions';
+
+      if (recipe.sourceUrl) {
+        const sourceLink = documentRef.createElement('a');
+        sourceLink.className = 'shopping-action-btn';
+        sourceLink.href = recipe.sourceUrl;
+        sourceLink.target = '_blank';
+        sourceLink.rel = 'noopener noreferrer';
+        sourceLink.textContent = 'Open source';
+        actions.appendChild(sourceLink);
+      }
+
+      if (ingredients.length) {
+        const shoppingButton = documentRef.createElement('button');
+        shoppingButton.type = 'button';
+        shoppingButton.className = 'shopping-action-btn';
+        shoppingButton.textContent = 'Add ingredients';
+        shoppingButton.addEventListener('click', async () => {
+          shoppingButton.disabled = true;
+          setStatus(`Adding ${ingredients.length} ingredients…`);
+          try {
+            await addIngredientsToShoppingList({ gun, listId, recipe });
+            setStatus(`${ingredients.length} ingredients added to the shared shopping list.`);
+          } catch {
+            setStatus('Ingredients could not be synced. Please try again.');
+          } finally {
+            shoppingButton.disabled = false;
+          }
+        });
+        actions.appendChild(shoppingButton);
+      }
+
+      const planLink = documentRef.createElement('a');
+      planLink.className = 'shopping-action-btn';
+      const planParams = new URLSearchParams({
+        menu: recipe.title,
+        recipe: recipe.id,
+        book: bookId,
+      });
+      planLink.href = `../meal-tracker/?${planParams.toString()}`;
+      planLink.textContent = 'Plan meal';
+      actions.appendChild(planLink);
+
+      const editButton = documentRef.createElement('button');
+      editButton.type = 'button';
+      editButton.className = 'shopping-action-btn';
+      editButton.textContent = 'Edit';
+      editButton.addEventListener('click', () => setEditState(recipe));
+
+      const deleteButton = documentRef.createElement('button');
+      deleteButton.type = 'button';
+      deleteButton.className = 'shopping-action-btn shopping-action-btn--ghost';
+      deleteButton.textContent = 'Delete';
+      deleteButton.addEventListener('click', () => {
+        const shouldDelete = windowRef?.confirm?.(`Delete "${recipe.title}" from this recipe book?`) ?? true;
+        if (!shouldDelete) return;
+        cache.delete(recipe.id);
+        recipeIndex.put({ [recipe.id]: false });
+        recipes.get(recipe.id).put(null);
+        if (editingId === recipe.id) resetForm();
+        renderRecipes();
+      });
+
+      actions.append(editButton, deleteButton);
+      card.appendChild(actions);
+      list.appendChild(card);
+    }
+
+    setStatus(`Synced ${cache.size} recipe${cache.size === 1 ? '' : 's'}.`);
+  };
+
+  const applyRecipeData = (data, key) => {
+    if (!data) {
+      cache.delete(key);
+      renderRecipes();
+      return;
+    }
+    cache.set(key, {
+      id: key,
+      title: data.title,
+      sourceUrl: normalizeHttpUrl(data.sourceUrl),
+      description: data.description,
+      servings: data.servings,
+      prepTime: data.prepTime,
+      cookTime: data.cookTime,
+      ingredients: safeJsonArray(data.ingredientsJson),
+      directions: safeJsonArray(data.directionsJson),
+      createdAt: data.createdAt,
+      updatedAt: data.updatedAt,
+    });
+    renderRecipes();
+  };
+
+  const subscribeToRecipe = (key) => {
+    if (!key || subscribedRecipes.has(key)) return;
+    subscribedRecipes.add(key);
+    recipes.get(key).on((data) => applyRecipeData(data, key));
+  };
+
+  recipeIndex.map().on((active, key) => {
+    if (!active) {
+      cache.delete(key);
+      renderRecipes();
+      return;
+    }
+    subscribeToRecipe(key);
+  });
+  recipes.map().on((data, key) => applyRecipeData(data, key));
+
+  form?.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    const title = titleInput.value.trim();
+    if (!title) return;
+
+    const existing = editingId ? cache.get(editingId) : null;
+    const id = editingId || `${Date.now()}-${Math.random().toString(16).slice(2, 8)}`;
+    const timestamp = Date.now();
+    submitButton.disabled = true;
+    setStatus(`Saving “${title}”…`);
+    try {
+      await putWithAcknowledgement(recipes.get(id), {
+        title,
+        sourceUrl: normalizeHttpUrl(urlInput.value),
+        description: descriptionInput.value.trim(),
+        servings: servingsInput.value.trim(),
+        prepTime: prepTimeInput.value.trim(),
+        cookTime: cookTimeInput.value.trim(),
+        ingredientsJson: JSON.stringify(parseIngredientLines(ingredientsInput.value)),
+        directionsJson: JSON.stringify(parseDirectionLines(directionsInput.value)),
+        createdAt: existing?.createdAt || timestamp,
+        updatedAt: timestamp,
+      });
+      await putWithAcknowledgement(recipeIndex, { [id]: true });
+      resetForm();
+      setStatus(`Saved “${title}”.`);
+    } catch {
+      setStatus('Recipe could not be synced. Please try again.');
+    } finally {
+      submitButton.disabled = false;
+    }
+  });
+
+  cancelButton?.addEventListener('click', resetForm);
+  searchInput?.addEventListener('input', renderRecipes);
+  copyButton?.addEventListener('click', async () => {
+    try {
+      if (windowRef?.navigator?.clipboard?.writeText) {
+        await windowRef.navigator.clipboard.writeText(shareUrl);
+      } else {
+        shareInput?.select?.();
+        if (!documentRef.execCommand?.('copy')) throw new Error('Clipboard unavailable');
+      }
+      setStatus('Family recipe-book link copied.');
+    } catch {
+      setStatus('Copy failed. Select the link above.');
+    }
+  });
+
+  renderRecipes();
+  return { bookId, listId, shareUrl };
+};
+
+if (typeof window !== 'undefined') {
+  window.addEventListener('DOMContentLoaded', () => initRecipeBook());
+}

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'tmsteph-pwa-v4';
+const CACHE_NAME = 'tmsteph-pwa-v5';
 const STATIC_ASSETS = [
   '/',
   '/index.html',
@@ -8,6 +8,13 @@ const STATIC_ASSETS = [
   '/opensource.html',
   '/spirituality.html',
   '/stagehand.html',
+  '/recipe-book/index.html',
+  '/recipe-book/recipe-book.js',
+  '/meal-tracker/index.html',
+  '/meal-tracker/meal-tracker.js',
+  '/shopping-list/index.html',
+  '/shopping-list/shopping-list.js',
+  '/clean-meals/index.html',
   '/pwa.js',
   '/login-status.js',
   '/favicon.ico',

--- a/shopping-list/index.html
+++ b/shopping-list/index.html
@@ -20,7 +20,11 @@
     <div class="container">
       <h1 class="handwritten">Shopping List</h1>
       <p class="tagline">Plan groceries, pantry staples, and household essentials together.</p>
-      <a href="../index.html" class="btn-primary">← Back to Home</a>
+      <div class="recipe-nav">
+        <a href="../index.html" class="btn-primary">← Back to Home</a>
+        <a href="../recipe-book/" class="btn-secondary">Recipe book</a>
+        <a href="../meal-tracker/" class="btn-secondary">Meal tracker</a>
+      </div>
     </div>
   </header>
 

--- a/style.css
+++ b/style.css
@@ -2714,3 +2714,38 @@ footer {
     align-items: flex-start;
   }
 }
+.recipe-nav {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.75rem;
+}
+
+.recipe-time-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(110px, 1fr));
+  gap: 0.75rem;
+}
+
+.recipe-time-grid label {
+  display: block;
+}
+
+.recipe-card {
+  padding: 1rem;
+}
+
+.recipe-card p {
+  white-space: pre-wrap;
+}
+
+.recipe-details {
+  margin: 0.5rem 0 1rem;
+  padding-left: 1.4rem;
+}
+
+.recipe-actions a {
+  display: inline-flex;
+  align-items: center;
+  text-decoration: none;
+}

--- a/tests/recipe-book.test.js
+++ b/tests/recipe-book.test.js
@@ -1,0 +1,249 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { JSDOM } from 'jsdom';
+import {
+  addIngredientsToShoppingList,
+  initRecipeBook,
+  parseDirectionLines,
+  parseIngredientLines,
+} from '../recipe-book/recipe-book.js';
+
+const baseMarkup = `
+  <form id="recipe-form">
+    <h3 id="recipe-form-title"></h3>
+    <input id="recipe-title">
+    <input id="recipe-url">
+    <textarea id="recipe-description"></textarea>
+    <input id="recipe-servings">
+    <input id="recipe-prep-time">
+    <input id="recipe-cook-time">
+    <textarea id="recipe-ingredients"></textarea>
+    <textarea id="recipe-directions"></textarea>
+    <button id="recipe-submit" type="submit">Save</button>
+    <button id="recipe-cancel" type="button"></button>
+  </form>
+  <input id="recipe-share-link">
+  <button id="recipe-copy-link" type="button"></button>
+  <p id="recipe-sync-status"></p>
+  <input id="recipe-search">
+  <p id="recipe-empty"></p>
+  <ul id="recipe-list"></ul>
+  <a id="recipe-shopping-link"></a>
+`;
+
+const createDom = (url = 'https://example.com/recipe-book/') =>
+  new JSDOM(`<!doctype html><html><body>${baseMarkup}</body></html>`, { url });
+
+const createGunMock = () => {
+  const paths = [];
+  const puts = [];
+  const subscriptions = [];
+
+  const createNode = (path = []) => ({
+    get: vi.fn((key) => {
+      const nextPath = [...path, key];
+      paths.push(nextPath);
+      return createNode(nextPath);
+    }),
+    put: vi.fn((value, callback) => {
+      puts.push({ path, value });
+      callback?.({ ok: 1 });
+      return createNode(path);
+    }),
+    map: vi.fn(() => ({
+      on: vi.fn((callback) => subscriptions.push({ path, callback, mapped: true })),
+    })),
+    on: vi.fn((callback) => subscriptions.push({ path, callback, mapped: false })),
+  });
+
+  return {
+    Gun: vi.fn(() => createNode()),
+    paths,
+    puts,
+    subscriptions,
+  };
+};
+
+const pathWasRequested = (paths, expectedPath) =>
+  paths.some((path) => path.join('/') === expectedPath.join('/'));
+
+describe('recipe book', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-26T12:00:00Z'));
+    vi.spyOn(Math, 'random').mockReturnValue(0.42);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('accepts realistic ingredient and direction data', () => {
+    expect(
+      parseIngredientLines(
+        '1 1/2 lb | boneless chicken thighs | Meat\n2 | lemons | Produce\nExtra-virgin olive oil'
+      )
+    ).toEqual([
+      { quantity: '1 1/2 lb', name: 'boneless chicken thighs', category: 'Meat' },
+      { quantity: '2', name: 'lemons', category: 'Produce' },
+      { quantity: '', name: 'Extra-virgin olive oil', category: 'Other' },
+    ]);
+    expect(parseDirectionLines('Heat oven to 425°F.\n\nRoast for 25–30 minutes.')).toEqual([
+      'Heat oven to 425°F.',
+      'Roast for 25–30 minutes.',
+    ]);
+  });
+
+  it('uses shareable recipe and shopping ids across isolated browsers', () => {
+    const sharedUrl =
+      'https://example.com/recipe-book/?book=stephens-family&list=weekly-groceries';
+    const firstBrowser = createDom(sharedUrl);
+    const secondBrowser = createDom(sharedUrl);
+    const firstGun = createGunMock();
+    const secondGun = createGunMock();
+
+    const first = initRecipeBook({
+      Gun: firstGun.Gun,
+      document: firstBrowser.window.document,
+      window: firstBrowser.window,
+    });
+    const second = initRecipeBook({
+      Gun: secondGun.Gun,
+      document: secondBrowser.window.document,
+      window: secondBrowser.window,
+    });
+
+    expect(first).toMatchObject({
+      bookId: 'stephens-family',
+      listId: 'weekly-groceries',
+    });
+    expect(second).toMatchObject({
+      bookId: 'stephens-family',
+      listId: 'weekly-groceries',
+    });
+    expect(
+      pathWasRequested(firstGun.paths, ['recipe-book', 'stephens-family', 'recipes'])
+    ).toBe(true);
+    expect(
+      pathWasRequested(secondGun.paths, ['recipe-book', 'stephens-family', 'recipes'])
+    ).toBe(true);
+    expect(firstBrowser.window.document.getElementById('recipe-shopping-link').href).toContain(
+      'list=weekly-groceries'
+    );
+  });
+
+  it('stores a link-only recipe without inventing ingredients or directions', async () => {
+    const dom = createDom(
+      'https://example.com/recipe-book/?book=stephens-family&list=weekly-groceries'
+    );
+    const gun = createGunMock();
+    const documentRef = dom.window.document;
+
+    initRecipeBook({ Gun: gun.Gun, document: documentRef, window: dom.window });
+    documentRef.getElementById('recipe-title').value = 'Serious Eats roast potatoes';
+    documentRef.getElementById('recipe-url').value =
+      'https://www.seriouseats.com/the-best-roast-potatoes-ever-recipe';
+    documentRef
+      .getElementById('recipe-form')
+      .dispatchEvent(new dom.window.Event('submit', { bubbles: true, cancelable: true }));
+    await vi.runAllTimersAsync();
+
+    const savedRecipe = gun.puts.find(
+      ({ path, value }) =>
+        path.slice(0, -1).join('/') === 'recipe-book/stephens-family/recipes' &&
+        value?.title === 'Serious Eats roast potatoes'
+    );
+    expect(savedRecipe?.value).toMatchObject({
+      sourceUrl: 'https://www.seriouseats.com/the-best-roast-potatoes-ever-recipe',
+      ingredientsJson: '[]',
+      directionsJson: '[]',
+    });
+  });
+
+  it('stores full recipe details in a Gun-safe representation', async () => {
+    const dom = createDom(
+      'https://example.com/recipe-book/?book=stephens-family&list=weekly-groceries'
+    );
+    const gun = createGunMock();
+    const documentRef = dom.window.document;
+
+    initRecipeBook({ Gun: gun.Gun, document: documentRef, window: dom.window });
+    documentRef.getElementById('recipe-title').value = 'Weeknight lemon chicken';
+    documentRef.getElementById('recipe-description').value = 'Reliable family dinner';
+    documentRef.getElementById('recipe-servings').value = '4';
+    documentRef.getElementById('recipe-ingredients').value =
+      '1 1/2 lb | chicken thighs | Meat\n2 | lemons | Produce';
+    documentRef.getElementById('recipe-directions').value =
+      'Heat oven to 425°F.\nRoast until chicken reaches 165°F.';
+    documentRef
+      .getElementById('recipe-form')
+      .dispatchEvent(new dom.window.Event('submit', { bubbles: true, cancelable: true }));
+    await vi.runAllTimersAsync();
+
+    const savedRecipe = gun.puts.find(
+      ({ value }) => value?.title === 'Weeknight lemon chicken'
+    )?.value;
+    expect(JSON.parse(savedRecipe.ingredientsJson)).toHaveLength(2);
+    expect(JSON.parse(savedRecipe.directionsJson)).toEqual([
+      'Heat oven to 425°F.',
+      'Roast until chicken reaches 165°F.',
+    ]);
+    expect(savedRecipe).toMatchObject({
+      description: 'Reliable family dinner',
+      servings: '4',
+    });
+  });
+
+  it('writes recipe ingredients into the exact shared shopping-list paths', async () => {
+    const gun = createGunMock();
+    const recipe = {
+      id: 'lemon-chicken',
+      title: 'Weeknight lemon chicken',
+      ingredients: [
+        { quantity: '1 1/2 lb', name: 'chicken thighs', category: 'Meat' },
+        { quantity: '2', name: 'lemons', category: 'Produce' },
+      ],
+    };
+
+    const ids = await addIngredientsToShoppingList({
+      gun: gun.Gun(),
+      listId: 'weekly-groceries',
+      recipe,
+      now: () => 1722000000000,
+      random: () => 0.42,
+    });
+
+    expect(ids).toHaveLength(2);
+    expect(
+      gun.puts.filter(
+        ({ path }) =>
+          path.slice(0, -1).join('/') === 'shopping-list/weekly-groceries/items'
+      )
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          value: expect.objectContaining({
+            name: 'chicken thighs',
+            quantity: '1 1/2 lb',
+            category: 'Meat',
+            sourceRecipeTitle: 'Weeknight lemon chicken',
+          }),
+        }),
+        expect.objectContaining({
+          value: expect.objectContaining({
+            name: 'lemons',
+            quantity: '2',
+            category: 'Produce',
+          }),
+        }),
+      ])
+    );
+    expect(
+      pathWasRequested(gun.paths, [
+        'shopping-list',
+        'weekly-groceries',
+        'item-index',
+      ])
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add a shared recipe book supporting link-only and full recipes
- connect recipes to the meal tracker and shared shopping list
- wait for GUN acknowledgements so saves and ingredient transfers reliably sync
- update navigation and PWA caching

## Validation
- `npm test` (45/45 passing)
- `npm run build`
- browser recipe-to-meal-planner flow
- live two-context GUN recipe and shopping-list sync