### PR TITLE
add Human Scale doctrine

### DIFF
--- a/human-scale/doctrine.md
+++ b/human-scale/doctrine.md
@@ -1,0 +1,196 @@
+# The Human Scale Doctrine
+
+**Version 0.1 — August 2026**
+
+> Humanity became powerful faster than it became wise.
+
+This is a living doctrine about human nature, technology, energy, community, ecology, and the kind of civilization worth building.
+
+It begins with a simple observation: human beings are biological organisms whose bodies and minds developed within nature, small communities, physical movement, direct relationships, seasonal rhythms, and meaningful dependence on the living world.
+
+Modern industrial civilization changed that environment at extraordinary speed.
+
+The problem is not that humanity learned too much. The problem is that our power to redesign the world grew faster than our understanding of what kind of world human beings actually need.
+
+## The Wrong Turn
+
+Fossil fuels gave humanity access to immense stores of concentrated energy. That energy multiplied transportation, manufacturing, extraction, construction, communication, and economic production.
+
+It also made it possible to redesign everyday life around machines.
+
+Cities spread outward. Work became increasingly abstract. Food traveled farther. Communities became less locally dependent. Artificial light extended the day. Cars reorganized public space. Screens reorganized attention. Institutions grew larger and more centralized.
+
+None of these inventions are automatically evil.
+
+The wrong turn was subtler: **we began optimizing civilization around what machines and markets could do instead of around what human beings need.**
+
+## The Human Mismatch
+
+The human animal still needs things that cannot be engineered away:
+
+- movement
+- sunlight
+- sleep
+- nature
+- family and friendship
+- belonging
+- meaningful work
+- play
+- beauty
+- touch
+- autonomy
+- purpose
+- periods of quiet
+- a livable environment
+
+A civilization can become more technologically sophisticated while becoming less compatible with the beings living inside it.
+
+That mismatch should become one of our central measures of progress.
+
+## Ten Theses
+
+1. **Human beings are biological organisms, not abstract economic units.** Any durable social system must begin with the realities of the body, mind, relationships, and ecology.
+
+2. **Our biology changes far more slowly than our technological environment.** Civilization can therefore create conditions that are materially advanced but psychologically or physically hostile.
+
+3. **Fossil energy accelerated this mismatch.** It allowed human environments, institutions, and consumption patterns to transform at a speed previously impossible.
+
+4. **Efficiency is not the same as flourishing.** A system can produce more goods, move faster, and generate more profit while making everyday life worse.
+
+5. **Technology is a tool, not a destiny.** We are allowed to decide which technologies deserve a place in human life and under what conditions.
+
+6. **Human-scale systems should be preferred when they work.** Local food, walkable places, small groups, repairable tools, distributed production, and understandable institutions often preserve agency and resilience.
+
+7. **Advanced technology should become quieter.** The best machines should remove drudgery and bureaucracy without consuming human attention, identity, and purpose.
+
+8. **Open systems protect human agency.** Knowledge, software, hardware, protocols, and infrastructure should be understandable, repairable, interoperable, and shareable whenever possible.
+
+9. **Ecology is not an externality.** Human civilization exists inside the living world, not outside it. Damage to soil, water, air, climate, biodiversity, and ecosystems eventually becomes damage to human life.
+
+10. **The future should recover what modernity discarded without discarding what humanity learned.** We do not need to choose between the village and the computer. We can build both.
+
+## What Progress Should Mean
+
+Progress should not be measured only by GDP, speed, scale, convenience, or computational power.
+
+A civilization is progressing when more people can:
+
+- live healthy lives
+- spend time with people they love
+- raise children in safe communities
+- understand and influence the systems around them
+- create rather than merely consume
+- work without surrendering their entire waking lives
+- access nature and public space
+- obtain food, shelter, education, and healthcare without permanent desperation
+- participate in culture and community
+- develop spiritually, intellectually, emotionally, and creatively
+- leave a healthy world to the next generation
+
+## The Technological Direction
+
+This doctrine is not anti-technology.
+
+It argues for **human-compatible technology**:
+
+- renewable and locally resilient energy
+- open-source software and hardware
+- distributed networks
+- repairable devices
+- local and flexible manufacturing
+- automation of dangerous, repetitive, and bureaucratic labor
+- AI that expands human agency rather than replacing human judgment everywhere
+- computing that disappears into the background when it is not needed
+- architecture and transportation that encourage movement and community
+- agricultural systems that regenerate rather than exhaust the land
+
+The goal is not maximum technology.
+
+The goal is the right technology in the right place, serving life.
+
+## The Social Direction
+
+Human-scale civilization should make it easier to form durable communities without forcing everyone into one ideology or lifestyle.
+
+It should favor:
+
+- strong families and chosen families
+- neighborhoods where people repeatedly encounter one another
+- voluntary associations
+- mutual aid
+- local ownership
+- cooperative creation
+- meaningful public spaces
+- decentralized political and economic power
+- cultural pluralism
+- freedom of belief
+- room for spiritual life
+
+Large systems will still exist. The principle is that scale should have to justify itself.
+
+## The Spiritual Direction
+
+Human beings have always searched for meaning.
+
+A humane civilization should make room for contemplation, ritual, prayer, meditation, art, music, mystery, philosophy, and direct encounters with nature without demanding one metaphysical explanation from everyone.
+
+Science can tell us an extraordinary amount about how the world works.
+
+It does not eliminate the human need to ask what life is for.
+
+## Doctrine Map
+
+This project can grow into connected bodies of thought:
+
+- Human Nature
+- Technology
+- Energy
+- Economics
+- Community
+- Education
+- Artificial Intelligence
+- Spirituality
+- Governance
+- Food and Agriculture
+- Architecture
+- Transportation
+- Work
+- Family
+- Health
+- Ecology
+- Open Source
+
+Each branch should eventually contain principles, evidence, unanswered questions, and practical experiments.
+
+## Open Questions
+
+This doctrine is intentionally unfinished.
+
+Among the questions still to explore:
+
+- Which parts of modern life create the greatest evolutionary mismatch?
+- Which technologies measurably improve human flourishing?
+- What is the ideal scale for different institutions?
+- How much localization is resilient without becoming isolationist?
+- How should ownership change in a highly automated economy?
+- What work should humans continue doing even when machines can do it?
+- How can dense cities become deeply connected to nature?
+- How do we preserve scientific rigor while allowing spiritual pluralism?
+- What should children learn in a civilization built around human flourishing?
+- How should AI be designed if attention, agency, and human development are primary values?
+
+## The Direction
+
+The future does not need to be a choice between technological acceleration and a romantic return to the past.
+
+We can keep the knowledge.
+
+We can keep the science.
+
+We can keep the computers.
+
+And we can use them to build a civilization in which people once again belong to their bodies, their communities, and the Earth.
+
+**The village and the computer can coexist.**
+
+This doctrine is an attempt to figure out how.

--- a/human-scale/index.html
+++ b/human-scale/index.html
@@ -1,0 +1,387 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>The Human Scale Doctrine — Thomas Stephens</title>
+  <meta name="description" content="A living doctrine about human nature, technology, energy, community, ecology, and building civilization around human flourishing." />
+  <meta name="theme-color" content="#07111f" />
+  <link rel="icon" href="../favicon.ico" type="image/x-icon" />
+  <style>
+    :root {
+      color-scheme: dark;
+      --bg: #07111f;
+      --panel: #0b1728;
+      --panel-soft: #102037;
+      --text: #e8eef7;
+      --muted: #a9b8cb;
+      --line: #22344c;
+      --sky: #78c8ff;
+      --sun: #ffe28a;
+      --green: #9ed8aa;
+    }
+
+    * { box-sizing: border-box; }
+
+    html { scroll-behavior: smooth; }
+
+    body {
+      margin: 0;
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      background:
+        radial-gradient(circle at 15% 0%, rgba(120, 200, 255, 0.12), transparent 34rem),
+        radial-gradient(circle at 90% 10%, rgba(158, 216, 170, 0.08), transparent 30rem),
+        var(--bg);
+      color: var(--text);
+      line-height: 1.72;
+    }
+
+    a { color: var(--sky); }
+
+    .topbar {
+      max-width: 1100px;
+      margin: 0 auto;
+      padding: 1.25rem 1.5rem 0;
+      display: flex;
+      justify-content: space-between;
+      gap: 1rem;
+      align-items: center;
+      color: var(--muted);
+      font-size: 0.95rem;
+    }
+
+    .topbar a {
+      text-decoration: none;
+      color: var(--muted);
+    }
+
+    .topbar a:hover { color: var(--text); }
+
+    header {
+      max-width: 980px;
+      margin: 0 auto;
+      padding: 7rem 1.5rem 5rem;
+      text-align: center;
+    }
+
+    .eyebrow {
+      text-transform: uppercase;
+      letter-spacing: 0.16em;
+      font-size: 0.78rem;
+      font-weight: 800;
+      color: var(--sky);
+    }
+
+    h1 {
+      margin: 0.7rem 0 1rem;
+      font-size: clamp(3rem, 9vw, 6.5rem);
+      line-height: 0.96;
+      letter-spacing: -0.055em;
+    }
+
+    .lead {
+      margin: 1.5rem auto 0;
+      max-width: 760px;
+      color: var(--muted);
+      font-size: clamp(1.12rem, 2.6vw, 1.4rem);
+    }
+
+    .thesis {
+      max-width: 830px;
+      margin: 2.5rem auto 0;
+      padding: 1.4rem 1.6rem;
+      border: 1px solid rgba(255, 226, 138, 0.28);
+      border-radius: 18px;
+      background: rgba(255, 226, 138, 0.055);
+      color: #fff4cf;
+      font-size: clamp(1.25rem, 3vw, 1.75rem);
+      font-weight: 750;
+    }
+
+    main {
+      width: min(100% - 2rem, 920px);
+      margin: 0 auto;
+      padding-bottom: 6rem;
+    }
+
+    section {
+      padding: 3.3rem 0;
+      border-top: 1px solid var(--line);
+    }
+
+    h2 {
+      margin: 0 0 1rem;
+      font-size: clamp(1.9rem, 5vw, 3rem);
+      letter-spacing: -0.035em;
+      line-height: 1.08;
+    }
+
+    h3 {
+      margin: 0;
+      font-size: 1.15rem;
+      line-height: 1.3;
+      color: #f4f8fc;
+    }
+
+    p { margin: 0.9rem 0; }
+
+    .muted { color: var(--muted); }
+
+    .callout {
+      margin: 2rem 0 0;
+      padding: 1.4rem 1.5rem;
+      border-left: 4px solid var(--sky);
+      border-radius: 0 14px 14px 0;
+      background: var(--panel);
+      font-size: 1.14rem;
+    }
+
+    .needs {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.65rem;
+      margin: 1.5rem 0 0;
+      padding: 0;
+      list-style: none;
+    }
+
+    .needs li {
+      border: 1px solid var(--line);
+      border-radius: 999px;
+      padding: 0.45rem 0.8rem;
+      background: rgba(255,255,255,0.025);
+      color: #dbe6f3;
+    }
+
+    .theses {
+      display: grid;
+      gap: 1rem;
+      margin-top: 1.7rem;
+    }
+
+    .thesis-card {
+      display: grid;
+      grid-template-columns: 3rem 1fr;
+      gap: 1rem;
+      padding: 1.2rem;
+      border: 1px solid var(--line);
+      border-radius: 16px;
+      background: linear-gradient(145deg, rgba(16,32,55,0.82), rgba(8,19,34,0.82));
+    }
+
+    .thesis-number {
+      width: 3rem;
+      height: 3rem;
+      display: grid;
+      place-items: center;
+      border-radius: 50%;
+      background: rgba(120, 200, 255, 0.1);
+      color: var(--sky);
+      font-weight: 850;
+    }
+
+    .thesis-card p {
+      margin: 0.45rem 0 0;
+      color: var(--muted);
+    }
+
+    .principles {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+      gap: 1rem;
+      margin-top: 1.4rem;
+    }
+
+    .principle {
+      padding: 1.25rem;
+      border: 1px solid var(--line);
+      border-radius: 16px;
+      background: var(--panel);
+    }
+
+    .principle p {
+      color: var(--muted);
+      margin-bottom: 0;
+    }
+
+    .map {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+      gap: 0.75rem;
+      margin-top: 1.4rem;
+    }
+
+    .map div {
+      padding: 0.9rem 1rem;
+      border-radius: 12px;
+      border: 1px solid var(--line);
+      background: rgba(158, 216, 170, 0.04);
+      color: #dceee1;
+      text-align: center;
+    }
+
+    .questions {
+      margin: 1.3rem 0 0;
+      padding-left: 1.25rem;
+      color: var(--muted);
+    }
+
+    .questions li { margin: 0.65rem 0; }
+
+    .closing {
+      text-align: center;
+      padding-bottom: 1rem;
+    }
+
+    .closing strong {
+      display: block;
+      margin: 2rem auto 0;
+      max-width: 760px;
+      color: var(--sun);
+      font-size: clamp(1.65rem, 5vw, 2.65rem);
+      line-height: 1.15;
+      letter-spacing: -0.035em;
+    }
+
+    .version {
+      margin-top: 2rem;
+      color: var(--muted);
+      font-size: 0.92rem;
+    }
+
+    footer {
+      border-top: 1px solid var(--line);
+      color: var(--muted);
+      text-align: center;
+      padding: 2.5rem 1.5rem 3.5rem;
+    }
+
+    footer a { text-decoration: none; }
+
+    @media (max-width: 620px) {
+      header { padding-top: 5rem; }
+      .thesis-card { grid-template-columns: 2.5rem 1fr; }
+      .thesis-number { width: 2.5rem; height: 2.5rem; }
+    }
+  </style>
+</head>
+<body>
+  <nav class="topbar" aria-label="Page navigation">
+    <a href="../index.html">← tmsteph home</a>
+    <span>Living doctrine · v0.1</span>
+  </nav>
+
+  <header>
+    <div class="eyebrow">Thomas Stephens · August 2026</div>
+    <h1>The Human Scale Doctrine</h1>
+    <p class="lead">A living framework about human nature, technology, energy, community, ecology, and the kind of civilization worth building.</p>
+    <div class="thesis">Humanity became powerful faster than it became wise.</div>
+  </header>
+
+  <main>
+    <section>
+      <h2>The premise</h2>
+      <p>Human beings are biological organisms whose bodies and minds developed within nature, small communities, physical movement, direct relationships, seasonal rhythms, and meaningful dependence on the living world.</p>
+      <p>Modern industrial civilization changed that environment at extraordinary speed.</p>
+      <div class="callout">The problem is not that humanity learned too much. The problem is that our power to redesign the world grew faster than our understanding of what kind of world human beings actually need.</div>
+    </section>
+
+    <section>
+      <h2>The wrong turn</h2>
+      <p>Fossil fuels gave humanity access to immense stores of concentrated energy. That energy multiplied transportation, manufacturing, extraction, construction, communication, and economic production.</p>
+      <p>It also made it possible to redesign everyday life around machines: cities spread outward, work became more abstract, food traveled farther, artificial light extended the day, cars reorganized public space, screens reorganized attention, and institutions grew larger and more centralized.</p>
+      <p>None of these inventions are automatically evil.</p>
+      <div class="callout">The wrong turn was subtler: <strong>we began optimizing civilization around what machines and markets could do instead of around what human beings need.</strong></div>
+    </section>
+
+    <section>
+      <h2>The human mismatch</h2>
+      <p class="muted">The human animal still needs things that cannot be engineered away.</p>
+      <ul class="needs">
+        <li>Movement</li><li>Sunlight</li><li>Sleep</li><li>Nature</li><li>Family</li><li>Friendship</li><li>Belonging</li><li>Meaningful work</li><li>Play</li><li>Beauty</li><li>Touch</li><li>Autonomy</li><li>Purpose</li><li>Quiet</li><li>A livable environment</li>
+      </ul>
+      <p>A civilization can become more technologically sophisticated while becoming less compatible with the beings living inside it.</p>
+    </section>
+
+    <section>
+      <h2>Ten theses</h2>
+      <div class="theses">
+        <article class="thesis-card"><div class="thesis-number">1</div><div><h3>Human beings are biological organisms, not abstract economic units.</h3><p>Durable systems must begin with the realities of the body, mind, relationships, and ecology.</p></div></article>
+        <article class="thesis-card"><div class="thesis-number">2</div><div><h3>Our biology changes more slowly than our technological environment.</h3><p>Civilization can therefore become materially advanced while creating psychologically or physically hostile conditions.</p></div></article>
+        <article class="thesis-card"><div class="thesis-number">3</div><div><h3>Fossil energy accelerated the mismatch.</h3><p>It allowed human environments, institutions, and consumption patterns to transform at a speed previously impossible.</p></div></article>
+        <article class="thesis-card"><div class="thesis-number">4</div><div><h3>Efficiency is not the same as flourishing.</h3><p>A system can produce more, move faster, and generate more profit while making everyday life worse.</p></div></article>
+        <article class="thesis-card"><div class="thesis-number">5</div><div><h3>Technology is a tool, not a destiny.</h3><p>We are allowed to decide which technologies deserve a place in human life and under what conditions.</p></div></article>
+        <article class="thesis-card"><div class="thesis-number">6</div><div><h3>Human-scale systems should be preferred when they work.</h3><p>Local food, walkable places, small groups, repairable tools, distributed production, and understandable institutions often preserve agency and resilience.</p></div></article>
+        <article class="thesis-card"><div class="thesis-number">7</div><div><h3>Advanced technology should become quieter.</h3><p>The best machines should remove drudgery and bureaucracy without consuming human attention, identity, and purpose.</p></div></article>
+        <article class="thesis-card"><div class="thesis-number">8</div><div><h3>Open systems protect human agency.</h3><p>Knowledge, software, hardware, protocols, and infrastructure should be understandable, repairable, interoperable, and shareable whenever possible.</p></div></article>
+        <article class="thesis-card"><div class="thesis-number">9</div><div><h3>Ecology is not an externality.</h3><p>Human civilization exists inside the living world. Damage to soil, water, air, climate, biodiversity, and ecosystems eventually becomes damage to human life.</p></div></article>
+        <article class="thesis-card"><div class="thesis-number">10</div><div><h3>Recover what modernity discarded without discarding what humanity learned.</h3><p>We do not need to choose between the village and the computer. We can build both.</p></div></article>
+      </div>
+    </section>
+
+    <section>
+      <h2>What progress should mean</h2>
+      <p>Progress should not be measured only by GDP, speed, scale, convenience, or computational power.</p>
+      <div class="principles">
+        <div class="principle"><h3>Healthy bodies</h3><p>Movement, sleep, nourishment, sunlight, clean air, and environments that support physical life.</p></div>
+        <div class="principle"><h3>Deep relationships</h3><p>Time with family, friends, children, neighbors, and communities that know one another.</p></div>
+        <div class="principle"><h3>Agency</h3><p>People should be able to understand and influence the systems that shape their lives.</p></div>
+        <div class="principle"><h3>Meaning</h3><p>Work, creativity, service, spirituality, learning, and participation in something larger than consumption.</p></div>
+        <div class="principle"><h3>Ecological continuity</h3><p>The world inherited by the next generation should remain capable of sustaining abundant life.</p></div>
+        <div class="principle"><h3>Time</h3><p>A wealthy civilization should return time to people, not merely fill every minute with more production and stimulation.</p></div>
+      </div>
+    </section>
+
+    <section>
+      <h2>The technological direction</h2>
+      <p>This doctrine is not anti-technology. It argues for <strong>human-compatible technology</strong>: renewable and locally resilient energy, open-source software and hardware, distributed networks, repairable devices, flexible manufacturing, automation of dangerous and bureaucratic labor, humane AI, and computing that can disappear into the background when it is not needed.</p>
+      <div class="callout">The goal is not maximum technology. The goal is the right technology in the right place, serving life.</div>
+    </section>
+
+    <section>
+      <h2>The social and spiritual direction</h2>
+      <p>Human-scale civilization should make it easier to form durable communities without forcing everyone into one ideology or lifestyle. It should favor strong families and chosen families, voluntary associations, mutual aid, local ownership, cooperative creation, public space, decentralized power, cultural pluralism, freedom of belief, and room for spiritual life.</p>
+      <p>Human beings have always searched for meaning. A humane civilization should make room for contemplation, ritual, prayer, meditation, art, music, mystery, philosophy, and direct encounters with nature without demanding one metaphysical explanation from everyone.</p>
+      <p class="muted">Science can tell us an extraordinary amount about how the world works. It does not eliminate the human need to ask what life is for.</p>
+    </section>
+
+    <section>
+      <h2>Doctrine map</h2>
+      <p class="muted">This is the beginning, not the finished system. Each branch can grow into principles, evidence, unanswered questions, and practical experiments.</p>
+      <div class="map">
+        <div>Human Nature</div><div>Technology</div><div>Energy</div><div>Economics</div><div>Community</div><div>Education</div><div>Artificial Intelligence</div><div>Spirituality</div><div>Governance</div><div>Food & Agriculture</div><div>Architecture</div><div>Transportation</div><div>Work</div><div>Family</div><div>Health</div><div>Ecology</div><div>Open Source</div>
+      </div>
+    </section>
+
+    <section>
+      <h2>Open questions</h2>
+      <ul class="questions">
+        <li>Which parts of modern life create the greatest mismatch with human nature?</li>
+        <li>Which technologies measurably improve human flourishing?</li>
+        <li>What is the ideal scale for different institutions?</li>
+        <li>How much localization creates resilience without becoming isolation?</li>
+        <li>How should ownership change in a highly automated economy?</li>
+        <li>What work should humans continue doing even when machines can do it?</li>
+        <li>How can dense cities become deeply connected to nature?</li>
+        <li>How do we preserve scientific rigor while allowing spiritual pluralism?</li>
+        <li>What should children learn in a civilization built around human flourishing?</li>
+        <li>How should AI be designed if attention, agency, and human development are primary values?</li>
+      </ul>
+    </section>
+
+    <section class="closing">
+      <h2>The direction</h2>
+      <p>The future does not need to be a choice between technological acceleration and a romantic return to the past.</p>
+      <p>We can keep the knowledge. We can keep the science. We can keep the computers.</p>
+      <p>And we can use them to build a civilization in which people once again belong to their bodies, their communities, and the Earth.</p>
+      <strong>The village and the computer can coexist.</strong>
+      <p class="version">This is version 0.1 of a living doctrine. It is expected to change as the ideas are challenged, tested, refined, and expanded.</p>
+    </section>
+  </main>
+
+  <footer>
+    <a href="../index.html">Thomas Stephens · tmsteph</a><br />
+    Dream. Build. Share.
+  </footer>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -147,6 +147,7 @@
       <a class="project-card" href="money.html">Money Re-Permissioning</a>
       <a class="project-card" href="politics/index.html">Political Beliefs</a>
       <a class="project-card" href="shared-human-values/index.html">Shared Human Values</a>
+      <a class="project-card" href="human-scale/index.html">Human Scale Doctrine</a>
       <a class="project-card" href="consciousness/">Consciousness</a>
       <a class="project-card" href="tantra/">Tantra · Approval Only</a>
       <a class="project-card" href="descent-return/index.html">Descent &amp; Return</a>


### PR DESCRIPTION
## What changed
- Added `human-scale/index.html` as a public, mobile-friendly Human Scale Doctrine v0.1 page.
- Added `human-scale/doctrine.md` as the editable source-of-truth for the evolving doctrine.
- Added a **Human Scale Doctrine** card to the tmsteph homepage.

## Why
This gives the broader philosophy a home on tmsteph.com, separate from 3DVR product/company messaging, while leaving room for the doctrine to grow into branches such as human nature, technology, energy, economics, community, AI, spirituality, ecology, food, architecture, and governance.

## Validation
- Compared the branch against `main`: exactly three intended files are changed.
- Confirmed the new page exists on the branch and begins with valid standalone HTML and responsive metadata.
- No application logic was changed; this is static content and homepage navigation only.