### PR TITLE
add Human Nature chapter

### DIFF
--- a/human-scale/doctrine.md
+++ b/human-scale/doctrine.md
@@ -1,6 +1,6 @@
 # The Human Scale Doctrine
 
-**Version 0.1 — August 2026**
+**Version 0.2 — August 2026**
 
 > Humanity became powerful faster than it became wise.
 
@@ -11,6 +11,34 @@ It begins with a simple observation: human beings are biological organisms whose
 Modern industrial civilization changed that environment at extraordinary speed.
 
 The problem is not that humanity learned too much. The problem is that our power to redesign the world grew faster than our understanding of what kind of world human beings actually need.
+
+## How to Use This Doctrine
+
+This doctrine is meant to help people do more than hold beliefs. It should help us understand the world, navigate it, and change it.
+
+Every major subject should eventually be developed in three layers:
+
+### Diagnosis
+
+What is happening? How did the current system develop? Which incentives, technologies, institutions, cultural habits, and physical environments shape the problem? Where does modern life conflict with recurring human needs?
+
+### Field Guide
+
+How can a person, family, or small group live better inside the world that exists now? What practical changes improve health, agency, competence, relationships, meaning, and resilience without requiring escape from society?
+
+### Program
+
+What should communities, institutions, businesses, cities, and governments change? Which reforms, technologies, public investments, ownership models, rules, and experiments could make human-compatible life easier for ordinary people?
+
+The doctrine should move repeatedly through the same cycle:
+
+**understand → adapt → organize → reform → build alternatives**
+
+And it should operate across a ladder of action:
+
+**Self → Household → Neighborhood → Institutions → City & Region → Economy & Government → Civilization**
+
+Higher-level change is not an excuse to neglect daily life. Personal adaptation is not an excuse to ignore structural problems.
 
 ## The Wrong Turn
 
@@ -138,11 +166,17 @@ Science can tell us an extraordinary amount about how the world works.
 
 It does not eliminate the human need to ask what life is for.
 
+## Chapters
+
+### 1. [Human Nature — The Environment We Were Built For](human-nature/index.html)
+
+The foundation of the doctrine. It introduces the mismatch lens, a practical Field Guide, a Human Scale policy test, and a ladder from personal action to societal change.
+
 ## Doctrine Map
 
 This project can grow into connected bodies of thought:
 
-- Human Nature
+- [Human Nature](human-nature/index.html)
 - Technology
 - Energy
 - Economics
@@ -161,6 +195,19 @@ This project can grow into connected bodies of thought:
 - Open Source
 
 Each branch should eventually contain principles, evidence, unanswered questions, and practical experiments.
+
+## Evidence Standard
+
+A serious doctrine must distinguish between different kinds of claims:
+
+- **Strong evidence** — supported across multiple methods, populations, or disciplines.
+- **Working hypothesis** — plausible and worth testing, but not settled.
+- **Value judgment** — a statement about the kind of life or society we consider desirable.
+- **Political proposal** — an intervention that must be evaluated for effectiveness, rights, cost, tradeoffs, unintended consequences, and public legitimacy.
+
+A scientific finding does not automatically determine a political answer, and a political preference should not be disguised as scientific certainty.
+
+The doctrine should be willing to change when reality contradicts it.
 
 ## Open Questions
 

--- a/human-scale/human-nature/chapter.md
+++ b/human-scale/human-nature/chapter.md
@@ -1,0 +1,430 @@
+# Chapter 1: Human Nature — The Environment We Were Built For
+
+**Human Scale Doctrine — Diagnosis / Field Guide / Program**
+
+> Before we redesign society, we need a better model of the creature who has to live inside it.
+
+This chapter starts from a simple premise: human beings are embodied, social, meaning-making organisms. We can adapt to an extraordinary range of environments, but adaptation is not infinite and it is not free.
+
+Modern civilization can change the conditions of daily life much faster than biological evolution can change the human organism. Culture can adapt faster than biology, but culture can also be overwhelmed, commercialized, centralized, or replaced.
+
+The Human Scale Doctrine calls the resulting gap **mismatch**: a condition in which an environment can be technologically impressive, economically productive, or convenient while still working against recurring human needs.
+
+This is not an argument that everything old is good or everything modern is bad. The past contained violence, disease, hierarchy, scarcity, and suffering that should not be romanticized.
+
+The task is more precise: **identify the parts of human nature that remain relevant, identify where modern systems conflict with them, and redesign life so that technology serves the organism instead of forcing the organism to serve the system.**
+
+---
+
+## 1. What We Mean by Human Nature
+
+Human nature is not one rigid lifestyle.
+
+Humans are unusually flexible. We live in deserts, forests, islands, dense cities, farms, mountains, and digital networks. We create radically different cultures.
+
+But flexibility exists inside constraints.
+
+Across human societies, several recurring needs appear again and again:
+
+- physical movement
+- sleep and daily rhythms
+- face-to-face relationships
+- belonging and mutual dependence
+- play and exploration
+- learning through doing
+- autonomy and meaningful choice
+- status and recognition
+- contribution to a group
+- contact with the physical world
+- periods of low stimulation
+- attachment, care, touch, and affection
+- meaning, story, ritual, or purpose
+- a functioning ecological environment
+
+The exact form varies. The underlying needs do not disappear because a new device, market, institution, or ideology arrives.
+
+---
+
+## 2. The Environment We Developed In
+
+For most of human existence, daily life required much more direct interaction with the body, other people, and the local environment than is required by industrial civilization.
+
+People generally had to move through physical space, respond to daylight and weather, cooperate with familiar groups, learn practical skills, care for children and elders, obtain food and materials from the living world, and directly experience many of the consequences of their decisions.
+
+This does **not** mean ancestral life was idyllic.
+
+It means that the human organism was shaped under conditions very different from:
+
+- sitting indoors for most waking hours
+- commuting long distances alone
+- receiving endless streams of information
+- performing abstract work for distant institutions
+- buying most necessities through global supply chains
+- spending large portions of childhood separated by age
+- sleeping under artificial light and around-the-clock stimulation
+- maintaining hundreds or thousands of weak digital connections while lacking nearby support
+- having entertainment, food, shopping, outrage, pornography, gambling, and social comparison available on demand
+- living in places where ordinary movement requires deliberate exercise rather than daily life
+
+The question is not whether modern humans *can* live this way.
+
+Clearly we can.
+
+The better question is: **what does it cost us, and which costs are avoidable?**
+
+---
+
+# Part I — Diagnosis
+
+## 3. The Mismatch Lens
+
+Mismatch is not a universal explanation for every human problem. It is a diagnostic tool.
+
+When we encounter a problem, we can ask:
+
+1. What human need or tendency is involved?
+2. What environment did that tendency normally operate within?
+3. What has changed about the modern environment?
+4. Who benefits from the new arrangement?
+5. Who carries the cost?
+6. Can the environment be redesigned instead of demanding more self-control from the individual?
+
+This matters because modern systems often treat predictable human responses as personal failures.
+
+If a city makes walking dangerous, inactivity is framed only as a motivation problem.
+
+If software is engineered to capture attention, distraction is framed only as a discipline problem.
+
+If parents are isolated from extended family and community, exhaustion is framed only as a parenting problem.
+
+If work consumes most useful waking hours, loneliness and lack of civic life are framed only as time-management problems.
+
+Personal responsibility matters. But responsibility without environmental analysis is incomplete.
+
+## 4. Major Areas of Possible Mismatch
+
+### Movement
+
+The body is not merely transportation for the brain. Movement affects how people work, play, socialize, learn, age, and experience place.
+
+A human-scale environment should make ordinary movement part of ordinary life rather than requiring everyone to purchase exercise as a separate activity.
+
+### Attention
+
+Human attention developed in environments where novel signals were limited compared with modern digital life.
+
+Today, attention is economically valuable. Entire industries compete to capture and retain it.
+
+A Human Scale analysis therefore treats attention not only as a personal habit but as a resource shaped by product design, business models, institutions, architecture, and law.
+
+### Relationships
+
+Humans can interact with far more people than ever before, yet quantity of contact is not the same as durable belonging.
+
+Human-scale communities create repeated encounters, shared responsibilities, reciprocal help, and places where relationships can deepen without being scheduled as special events.
+
+### Work
+
+Work can provide money, skill, contribution, identity, cooperation, and meaning. It can also become detached from visible purpose and local consequence.
+
+The Human Scale question is not simply how to eliminate work. It is how to reduce needless drudgery while preserving agency, competence, contribution, craftsmanship, and social usefulness.
+
+### Childhood
+
+Children learn through attachment, imitation, play, experimentation, physical movement, responsibility, and gradually increasing independence.
+
+A Human Scale society should ask whether homes, schools, streets, schedules, technologies, and legal norms support those developmental needs or unintentionally suppress them.
+
+### Nature and sensory life
+
+Human life developed inside a world of changing light, weather, plants, animals, soil, water, sound, texture, and season.
+
+Nature should not be treated only as a vacation destination or decorative amenity. Contact with the living world can be a normal part of neighborhoods, schools, workplaces, healthcare, food systems, and public space.
+
+### Food, sleep, and rhythm
+
+Industrial systems can make highly stimulating food, artificial light, irregular schedules, and around-the-clock consumption normal.
+
+The question is not whether individuals should exercise discipline. The question is why environments routinely make biological regulation difficult and whether healthier defaults can be designed.
+
+---
+
+## 5. Avoiding the Naturalistic Fallacy
+
+"Natural" does not automatically mean "good."
+
+Humans are capable of aggression, domination, tribalism, jealousy, exploitation, and cruelty as well as cooperation, care, creativity, and love.
+
+The Human Scale Doctrine does not argue that society should reproduce every ancestral condition or every human impulse.
+
+Instead:
+
+- biology tells us what kinds of creatures we are
+- history tells us what humans have done
+- science helps us test consequences
+- ethics helps us decide what should be encouraged or restrained
+- politics determines how shared rules are negotiated
+- design shapes the environments in which choices are made
+
+Human nature is a starting constraint, not a moral command.
+
+---
+
+## 6. Evidence Discipline
+
+A serious doctrine must be able to say, "we do not know."
+
+For each major claim, future versions should distinguish among:
+
+**Strong evidence** — findings supported across multiple methods, populations, or disciplines.
+
+**Working hypothesis** — a plausible explanation worth testing but not yet strong enough to treat as settled.
+
+**Value judgment** — a statement about what kind of life or society we consider desirable.
+
+**Political proposal** — a specific intervention that must be evaluated for effectiveness, tradeoffs, rights, cost, unintended consequences, and public legitimacy.
+
+This separation matters. A scientific finding does not automatically determine a political answer, and a political preference should not be disguised as scientific certainty.
+
+---
+
+# Part II — Field Guide
+
+## 7. How to Live More Humanly Inside the Existing World
+
+The goal is not purity. Most people cannot immediately leave their job, move to a farm, abandon technology, rebuild their neighborhood, or reorganize their family structure.
+
+The Field Guide asks: **what small changes move life toward human compatibility without requiring escape from society?**
+
+### Restore bodily rhythm
+
+Build movement, daylight, meals, rest, and sleep into the structure of the day instead of treating the body as an obstacle to productivity.
+
+### Protect attention
+
+Create places and periods where nothing is trying to sell, notify, recommend, measure, or provoke.
+
+Use technology intentionally. Turn off unnecessary signals. Prefer tools that finish a task and get out of the way.
+
+### Build repeated local relationships
+
+Know neighbors. Use nearby businesses and public spaces. Join recurring groups. Help people before an emergency creates the need.
+
+Community is difficult to manufacture during a crisis if it was never practiced during ordinary life.
+
+### Recover useful competence
+
+Cook. Repair. Grow something. Make music. Build things. Care for children. Learn first aid. Fix a bicycle. Understand basic finances. Participate in civic meetings. Learn how local infrastructure works.
+
+The point is not self-sufficiency in everything. It is reducing helplessness.
+
+### Choose friction when friction is healthy
+
+Convenience is valuable, but removing every effort can remove movement, skill, patience, social contact, and awareness.
+
+Sometimes walking, cooking, repairing, waiting, practicing, carrying, making, or talking to a human is better than eliminating the friction.
+
+### Create real rest
+
+Rest is not the same as passive stimulation.
+
+Protect some time for sleep, silence, prayer, meditation, conversation, music, wandering, reading, nature, and unstructured play.
+
+### Audit the environment before blaming yourself
+
+When a habit repeatedly fails, ask what in the environment makes the unwanted behavior easy and the desired behavior hard.
+
+Then change the environment where possible.
+
+---
+
+## 8. A Personal Human Scale Audit
+
+For one week, observe without trying to perfect anything.
+
+At the end of each day, ask:
+
+- How much did I move naturally?
+- How much daylight and outdoor time did I get?
+- Did I have unhurried contact with someone I care about?
+- What captured most of my attention?
+- What work felt useful or meaningful?
+- When did I feel competent and capable?
+- When did I feel powerless inside a system I did not understand?
+- What did I create?
+- What did I consume?
+- Did I experience quiet?
+- What part of my day felt most human?
+- What part felt most machine-like?
+
+Do not turn this into another optimization score.
+
+Look for patterns.
+
+---
+
+# Part III — Program
+
+## 9. From Personal Adaptation to Social Change
+
+A doctrine that only teaches individuals to cope with unhealthy systems is incomplete.
+
+If a problem is repeatedly produced by infrastructure, incentives, institutions, or law, then the environment itself becomes a legitimate target for change.
+
+The Program therefore asks how communities, governments, businesses, schools, and technologies can make human-compatible choices easier and more ordinary.
+
+## 10. Design Goals for a Human-Scale Society
+
+### Daily life should allow movement
+
+Neighborhoods should make walking, cycling, transit, play, and access to daily needs realistic choices rather than special lifestyle preferences.
+
+### Public space should create belonging
+
+Parks, libraries, markets, sidewalks, plazas, community centers, playgrounds, and other shared spaces should make repeated local encounter possible without requiring a purchase.
+
+### Children should have room to develop agency
+
+Communities should examine whether streets, schools, housing, schedules, and public spaces allow children increasing independence, outdoor play, responsibility, and relationships across generations.
+
+### Work should leave room for life
+
+Economic institutions should be judged partly by whether people retain enough time and predictability for sleep, family, friendship, caregiving, civic participation, health, creativity, and rest.
+
+### Technology should respect attention and agency
+
+Users should be able to understand, control, leave, repair, modify, or replace important technologies wherever practical.
+
+Business models that depend on compulsive engagement deserve special scrutiny when they shape childhood, public discourse, mental life, or essential services.
+
+### Healthy choices should not require exceptional privilege
+
+Access to safe housing, movement, nutritious food, education, healthcare, nature, clean air, and community should be treated as infrastructure questions, not merely consumer preferences.
+
+### Decision-making should occur at the smallest workable scale
+
+Local control can increase understanding, accountability, experimentation, and participation.
+
+But localism is not automatically just or competent. Some problems require regional, national, or global coordination.
+
+The principle is not "local good, large bad." The principle is: **scale should justify itself.**
+
+### Ecology should be designed into ordinary life
+
+Cities, agriculture, energy, transportation, housing, and industry should be evaluated as parts of ecosystems rather than as systems operating outside nature.
+
+---
+
+## 11. The Human Scale Policy Test
+
+Before supporting a policy, technology, development, institution, or reform, ask:
+
+1. Does it improve or degrade human health?
+2. Does it increase or reduce meaningful agency?
+3. Does it strengthen or weaken durable relationships and community?
+4. Does it return time to people or consume more of it?
+5. Does it make the system easier to understand and influence?
+6. Does it protect the ecological systems human life depends on?
+7. Who receives the benefits, and who carries the costs?
+8. What happens if the system fails?
+9. Can people opt out or choose an alternative?
+10. Is the scale necessary for the problem being solved?
+
+No policy will score perfectly.
+
+The test exists to expose tradeoffs that conventional measures can hide.
+
+---
+
+## 12. A Ladder of Action
+
+Human-scale change can happen at several levels:
+
+**Self** — habits, attention, skills, health, consumption, work, civic understanding.
+
+**Family and household** — rhythms, caregiving, food, media, money, learning, shared responsibilities.
+
+**Neighborhood** — relationships, mutual aid, public space, local commerce, safety, mobility.
+
+**Community and institutions** — schools, workplaces, churches, clubs, nonprofits, cooperatives, libraries, healthcare.
+
+**City and region** — land use, transportation, housing, parks, utilities, public services, local democracy.
+
+**Economy and government** — labor rules, ownership structures, competition, taxation, safety nets, infrastructure, regulation, public investment.
+
+**Civilization** — energy systems, AI, ecological limits, global coordination, cultural stories, definitions of progress.
+
+The higher levels should not become an excuse to neglect the lower ones.
+
+The lower levels should not become an excuse to ignore structural problems.
+
+---
+
+## 13. Experiments Before Dogma
+
+Whenever possible, test ideas at small scale.
+
+A neighborhood can try a temporary street closure before permanent reconstruction.
+
+A school can test outdoor learning.
+
+A workplace can test shorter or more predictable scheduling.
+
+A community can build a repair cafe, tool library, garden, parent cooperative, or local mesh network.
+
+A city can compare different street designs, public-space programs, or permitting rules.
+
+A person can test a week with fewer notifications, more walking, shared meals, or scheduled community time.
+
+The doctrine should collect these experiments, including failures.
+
+---
+
+## 14. What Would Change Our Minds?
+
+Human Scale ideas should be revisable.
+
+We should change a claim when better evidence shows that:
+
+- the proposed mismatch is not actually harmful
+- a supposedly human-scale intervention produces worse outcomes
+- a large centralized system reliably protects human flourishing better than a smaller alternative
+- a technology thought to damage agency can be designed or governed to improve it
+- a cherished tradition causes more harm than benefit
+- a policy creates serious unintended consequences that outweigh its gains
+
+A doctrine becomes dangerous when preserving the doctrine becomes more important than understanding reality.
+
+---
+
+## 15. Open Questions
+
+- Which human needs are most universal, and which are primarily cultural?
+- Which modern mismatches cause the greatest preventable harm?
+- How do poverty, disability, gender, age, race, geography, and culture alter the experience of mismatch?
+- How should cities balance density, nature, privacy, mobility, affordability, and community?
+- Which aspects of digital life can be redesigned rather than rejected?
+- How much work is necessary in a highly automated society, and how should its benefits be distributed?
+- What forms of community work for people who do not fit traditional family or religious structures?
+- Which decisions truly benefit from local control, and which require larger coordination?
+- How do we measure flourishing without turning human life into another dashboard?
+
+---
+
+## 16. The Direction
+
+The purpose of studying human nature is not to imprison people in the past.
+
+It is to give the future a better design brief.
+
+We can build cities with computers and trees.
+
+We can automate drudgery without automating meaning.
+
+We can use global knowledge while rebuilding local competence.
+
+We can protect individual freedom while creating conditions where community is easier.
+
+We can keep scientific and technological progress while asking it to serve bodies, relationships, ecosystems, and human purpose.
+
+**The goal is not to become primitive. The goal is to become compatible with ourselves.**

--- a/human-scale/human-nature/index.html
+++ b/human-scale/human-nature/index.html
@@ -1,0 +1,363 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Human Nature — The Environment We Were Built For</title>
+  <meta name="description" content="Chapter 1 of the Human Scale Doctrine: human nature, evolutionary mismatch, practical navigation, and social change." />
+  <meta name="theme-color" content="#07111f" />
+  <link rel="icon" href="../../favicon.ico" type="image/x-icon" />
+  <style>
+    :root {
+      color-scheme: dark;
+      --bg: #07111f;
+      --panel: #0c192a;
+      --soft: #11233a;
+      --text: #edf3fa;
+      --muted: #aab9ca;
+      --line: #243850;
+      --sky: #7bcaff;
+      --sun: #ffe18a;
+      --green: #a4d9ad;
+    }
+    * { box-sizing: border-box; }
+    html { scroll-behavior: smooth; }
+    body {
+      margin: 0;
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      color: var(--text);
+      line-height: 1.72;
+      background:
+        radial-gradient(circle at 15% 0%, rgba(123,202,255,.12), transparent 34rem),
+        radial-gradient(circle at 92% 8%, rgba(164,217,173,.09), transparent 30rem),
+        var(--bg);
+    }
+    a { color: var(--sky); }
+    .topbar {
+      width: min(100% - 2rem, 1080px);
+      margin: 0 auto;
+      padding: 1.25rem 0;
+      display: flex;
+      justify-content: space-between;
+      gap: 1rem;
+      color: var(--muted);
+      font-size: .94rem;
+    }
+    .topbar a { color: var(--muted); text-decoration: none; }
+    .topbar a:hover { color: var(--text); }
+    header {
+      width: min(100% - 2rem, 900px);
+      margin: 0 auto;
+      padding: 5.5rem 0 4.2rem;
+      text-align: center;
+    }
+    .eyebrow {
+      color: var(--sky);
+      text-transform: uppercase;
+      letter-spacing: .16em;
+      font-weight: 800;
+      font-size: .78rem;
+    }
+    h1 {
+      margin: .8rem 0 1rem;
+      font-size: clamp(2.8rem, 8vw, 5.8rem);
+      line-height: .98;
+      letter-spacing: -.05em;
+    }
+    .lead {
+      max-width: 740px;
+      margin: 1.3rem auto 0;
+      color: var(--muted);
+      font-size: clamp(1.1rem, 2.5vw, 1.35rem);
+    }
+    .thesis {
+      max-width: 800px;
+      margin: 2.2rem auto 0;
+      padding: 1.35rem 1.5rem;
+      border: 1px solid rgba(255,225,138,.28);
+      border-radius: 18px;
+      background: rgba(255,225,138,.05);
+      color: #fff2c7;
+      font-size: clamp(1.2rem, 3vw, 1.65rem);
+      font-weight: 750;
+    }
+    main { width: min(100% - 2rem, 900px); margin: 0 auto; padding-bottom: 6rem; }
+    section { padding: 3.2rem 0; border-top: 1px solid var(--line); }
+    h2 { margin: 0 0 1rem; font-size: clamp(1.8rem, 5vw, 2.8rem); line-height: 1.08; letter-spacing: -.035em; }
+    h3 { margin: 1.5rem 0 .5rem; font-size: 1.25rem; }
+    p { margin: .9rem 0; }
+    .muted { color: var(--muted); }
+    .callout {
+      margin: 1.6rem 0 0;
+      padding: 1.3rem 1.4rem;
+      border-left: 4px solid var(--sky);
+      border-radius: 0 14px 14px 0;
+      background: var(--panel);
+      font-size: 1.1rem;
+    }
+    .three {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px,1fr));
+      gap: 1rem;
+      margin-top: 1.5rem;
+    }
+    .card {
+      padding: 1.3rem;
+      border: 1px solid var(--line);
+      border-radius: 16px;
+      background: linear-gradient(145deg, rgba(17,35,58,.9), rgba(8,19,34,.9));
+    }
+    .card h3 { margin-top: 0; color: #f5f9fd; }
+    .card p { color: var(--muted); margin-bottom: 0; }
+    .lens {
+      display: grid;
+      gap: .8rem;
+      margin-top: 1.2rem;
+    }
+    .lens div {
+      padding: 1rem 1.1rem;
+      border: 1px solid var(--line);
+      border-radius: 14px;
+      background: rgba(255,255,255,.025);
+    }
+    ul, ol { padding-left: 1.3rem; }
+    li { margin: .55rem 0; }
+    .part {
+      color: var(--green);
+      text-transform: uppercase;
+      letter-spacing: .14em;
+      font-size: .78rem;
+      font-weight: 850;
+      margin-bottom: .55rem;
+    }
+    .audit {
+      display: grid;
+      gap: .7rem;
+      margin-top: 1.3rem;
+    }
+    .audit div {
+      padding: .95rem 1rem;
+      border-radius: 12px;
+      background: var(--panel);
+      border: 1px solid var(--line);
+    }
+    .action-ladder {
+      display: grid;
+      grid-template-columns: repeat(auto-fit,minmax(210px,1fr));
+      gap: .8rem;
+      margin-top: 1.3rem;
+    }
+    .action-ladder div {
+      border: 1px solid var(--line);
+      background: rgba(164,217,173,.04);
+      border-radius: 14px;
+      padding: 1rem;
+    }
+    .action-ladder strong { display:block; color: #dff1e3; margin-bottom:.35rem; }
+    .policy-test li { padding-left: .2rem; }
+    .closing { text-align: center; }
+    .closing strong {
+      display: block;
+      margin: 2rem auto 0;
+      max-width: 760px;
+      color: var(--sun);
+      font-size: clamp(1.55rem, 4.5vw, 2.5rem);
+      line-height: 1.15;
+      letter-spacing: -.03em;
+    }
+    footer { border-top:1px solid var(--line); padding:2.5rem 1rem 3.5rem; text-align:center; color:var(--muted); }
+    footer a { text-decoration:none; }
+  </style>
+</head>
+<body>
+  <nav class="topbar" aria-label="Page navigation">
+    <a href="../index.html">← Human Scale Doctrine</a>
+    <span>Chapter 1 · Human Nature</span>
+  </nav>
+
+  <header>
+    <div class="eyebrow">Diagnosis · Field Guide · Program</div>
+    <h1>Human Nature</h1>
+    <p class="lead">The environment we were built for — and what that means for navigating modern life and changing the systems around us.</p>
+    <div class="thesis">Before we redesign society, we need a better model of the creature who has to live inside it.</div>
+  </header>
+
+  <main>
+    <section>
+      <h2>The starting point</h2>
+      <p>Human beings are embodied, social, meaning-making organisms. We can adapt to an extraordinary range of environments, but adaptation is not infinite and it is not free.</p>
+      <p>Modern civilization can change the conditions of daily life much faster than biological evolution can change the human organism. Culture can adapt faster than biology, but culture can also be overwhelmed, centralized, commercialized, or replaced.</p>
+      <div class="callout"><strong>Mismatch</strong> is the gap between recurring human needs and an environment that may be technologically impressive, economically productive, or convenient while still working against those needs.</div>
+      <p class="muted">This is not an argument that everything old is good or everything modern is bad. The past contained suffering that should not be romanticized. The task is to recover what serves human life while keeping what humanity has learned.</p>
+    </section>
+
+    <section>
+      <h2>What we mean by human nature</h2>
+      <p>Human nature is not one rigid lifestyle. Humans are unusually flexible, but flexibility exists inside constraints.</p>
+      <div class="three">
+        <div class="card"><h3>Body</h3><p>Movement, sleep, light, food, touch, rest, sensory life, and a functioning physical environment.</p></div>
+        <div class="card"><h3>Relationship</h3><p>Attachment, friendship, belonging, mutual dependence, recognition, caregiving, and contribution to a group.</p></div>
+        <div class="card"><h3>Meaning</h3><p>Autonomy, competence, play, learning, story, ritual, creativity, service, spirituality, and purpose.</p></div>
+      </div>
+      <p>The form varies across cultures. The underlying needs do not simply disappear because a new device, market, institution, or ideology arrives.</p>
+    </section>
+
+    <section>
+      <div class="part">Part I — Diagnosis</div>
+      <h2>The mismatch lens</h2>
+      <p>Mismatch is not a universal explanation for every human problem. It is a diagnostic tool.</p>
+      <ol>
+        <li>What human need or tendency is involved?</li>
+        <li>What environment did that tendency normally operate within?</li>
+        <li>What changed in the modern environment?</li>
+        <li>Who benefits from the new arrangement?</li>
+        <li>Who carries the cost?</li>
+        <li>Can the environment be redesigned instead of demanding more self-control from the individual?</li>
+      </ol>
+      <div class="callout">Personal responsibility matters. But responsibility without environmental analysis is incomplete.</div>
+    </section>
+
+    <section>
+      <h2>Where mismatch may show up</h2>
+      <div class="lens">
+        <div><strong>Movement.</strong> Ordinary life can require so little physical movement that exercise becomes a separate purchased activity.</div>
+        <div><strong>Attention.</strong> Attention is economically valuable, and modern products can compete continuously to capture it.</div>
+        <div><strong>Relationships.</strong> Huge networks of weak contact can coexist with little nearby, durable, reciprocal support.</div>
+        <div><strong>Work.</strong> Work can provide contribution and competence, but can also become abstract, externally controlled, and detached from visible purpose.</div>
+        <div><strong>Childhood.</strong> Children need attachment, play, movement, responsibility, imitation, and gradually increasing independence.</div>
+        <div><strong>Nature.</strong> The living world can become something visited occasionally instead of something woven through daily life.</div>
+        <div><strong>Food, sleep, and rhythm.</strong> Artificial light, irregular schedules, constant stimulation, and highly engineered consumption environments can make regulation harder.</div>
+      </div>
+    </section>
+
+    <section>
+      <h2>Do not confuse natural with good</h2>
+      <p>Humans are capable of aggression, domination, tribalism, jealousy, exploitation, care, cooperation, creativity, love, and much more.</p>
+      <p>Human nature is a starting constraint, not a moral command.</p>
+      <div class="three">
+        <div class="card"><h3>Biology</h3><p>Helps describe what kinds of creatures we are.</p></div>
+        <div class="card"><h3>Evidence</h3><p>Helps test consequences and distinguish intuition from reality.</p></div>
+        <div class="card"><h3>Ethics & politics</h3><p>Help decide what should be encouraged, restrained, protected, funded, or changed.</p></div>
+      </div>
+    </section>
+
+    <section>
+      <h2>Evidence discipline</h2>
+      <p>A serious doctrine must be able to say, <strong>we do not know.</strong></p>
+      <div class="three">
+        <div class="card"><h3>Strong evidence</h3><p>Claims supported across multiple methods, populations, or disciplines.</p></div>
+        <div class="card"><h3>Working hypothesis</h3><p>A plausible explanation worth testing, but not strong enough to treat as settled.</p></div>
+        <div class="card"><h3>Value judgment</h3><p>A statement about what kind of life or society we consider desirable.</p></div>
+      </div>
+      <div class="callout">A scientific finding does not automatically determine a political answer, and a political preference should never be disguised as scientific certainty.</div>
+    </section>
+
+    <section>
+      <div class="part">Part II — Field Guide</div>
+      <h2>Living more humanly inside the existing world</h2>
+      <p>The goal is not purity or escape. The Field Guide asks what small changes move life toward human compatibility without requiring a person to abandon modern society.</p>
+      <div class="three">
+        <div class="card"><h3>Restore bodily rhythm</h3><p>Build movement, daylight, meals, rest, and sleep into the structure of the day.</p></div>
+        <div class="card"><h3>Protect attention</h3><p>Create periods where nothing is trying to sell, notify, recommend, measure, or provoke.</p></div>
+        <div class="card"><h3>Build local relationships</h3><p>Know neighbors, use public spaces, join recurring groups, and practice mutual help before crisis.</p></div>
+        <div class="card"><h3>Recover competence</h3><p>Cook, repair, grow, build, create, care, learn first aid, understand money, and learn how local systems work.</p></div>
+        <div class="card"><h3>Choose healthy friction</h3><p>Walking, cooking, repairing, practicing, waiting, and talking to humans can preserve skill and awareness.</p></div>
+        <div class="card"><h3>Create real rest</h3><p>Make room for sleep, silence, prayer, meditation, conversation, music, reading, nature, and unstructured play.</p></div>
+      </div>
+    </section>
+
+    <section>
+      <h2>A one-week Human Scale audit</h2>
+      <p class="muted">Observe first. Do not turn this into another optimization score.</p>
+      <div class="audit">
+        <div>How much did I move naturally?</div>
+        <div>How much daylight and outdoor time did I get?</div>
+        <div>Did I have unhurried contact with someone I care about?</div>
+        <div>What captured most of my attention?</div>
+        <div>What work felt useful or meaningful?</div>
+        <div>When did I feel competent and capable?</div>
+        <div>When did I feel powerless inside a system I did not understand?</div>
+        <div>What did I create? What did I consume?</div>
+        <div>Did I experience quiet?</div>
+        <div>What part of my day felt most human? What part felt most machine-like?</div>
+      </div>
+    </section>
+
+    <section>
+      <div class="part">Part III — Program</div>
+      <h2>From coping to changing the environment</h2>
+      <p>A doctrine that only teaches individuals to cope with unhealthy systems is incomplete.</p>
+      <p>If a problem is repeatedly produced by infrastructure, incentives, institutions, product design, or law, then the environment itself becomes a legitimate target for change.</p>
+      <div class="three">
+        <div class="card"><h3>Movement by default</h3><p>Make walking, cycling, transit, play, and access to daily needs realistic choices.</p></div>
+        <div class="card"><h3>Public belonging</h3><p>Create parks, libraries, markets, sidewalks, plazas, playgrounds, and community spaces that do not require a purchase.</p></div>
+        <div class="card"><h3>Child agency</h3><p>Design streets, schools, housing, schedules, and public spaces for play, responsibility, and increasing independence.</p></div>
+        <div class="card"><h3>Time for life</h3><p>Judge work partly by whether people retain time and predictability for family, health, civic life, creativity, and rest.</p></div>
+        <div class="card"><h3>Humane technology</h3><p>Protect attention, user control, interoperability, repairability, choice, and the ability to leave.</p></div>
+        <div class="card"><h3>Healthy defaults</h3><p>Treat safe housing, movement, food, education, healthcare, nature, clean air, and community as design and infrastructure questions.</p></div>
+      </div>
+    </section>
+
+    <section>
+      <h2>The Human Scale policy test</h2>
+      <ol class="policy-test">
+        <li>Does it improve or degrade human health?</li>
+        <li>Does it increase or reduce meaningful agency?</li>
+        <li>Does it strengthen or weaken durable relationships and community?</li>
+        <li>Does it return time to people or consume more of it?</li>
+        <li>Does it make the system easier to understand and influence?</li>
+        <li>Does it protect the ecological systems human life depends on?</li>
+        <li>Who receives the benefits, and who carries the costs?</li>
+        <li>What happens if the system fails?</li>
+        <li>Can people opt out or choose an alternative?</li>
+        <li>Is the scale necessary for the problem being solved?</li>
+      </ol>
+      <p class="muted">No policy will score perfectly. The test exists to expose tradeoffs that conventional measures can hide.</p>
+    </section>
+
+    <section>
+      <h2>A ladder of action</h2>
+      <div class="action-ladder">
+        <div><strong>Self</strong>Habits, health, attention, skills, consumption, work, civic understanding.</div>
+        <div><strong>Household</strong>Caregiving, food, media, money, learning, rhythms, shared responsibilities.</div>
+        <div><strong>Neighborhood</strong>Relationships, public space, local commerce, safety, mobility, mutual aid.</div>
+        <div><strong>Institutions</strong>Schools, workplaces, churches, clubs, cooperatives, libraries, healthcare.</div>
+        <div><strong>City & region</strong>Housing, land use, transportation, parks, utilities, public services, local democracy.</div>
+        <div><strong>Economy & government</strong>Labor rules, ownership, competition, taxation, safety nets, infrastructure, regulation.</div>
+        <div><strong>Civilization</strong>Energy, AI, ecology, global coordination, cultural stories, definitions of progress.</div>
+      </div>
+      <div class="callout">Higher-level change is not an excuse to neglect daily life. Personal adaptation is not an excuse to ignore structural problems.</div>
+    </section>
+
+    <section>
+      <h2>Experiments before dogma</h2>
+      <p>Whenever possible, test ideas at small scale and keep the failures.</p>
+      <ul>
+        <li>Temporary street changes before permanent reconstruction.</li>
+        <li>Outdoor learning experiments in schools.</li>
+        <li>Shorter or more predictable scheduling trials at work.</li>
+        <li>Repair cafes, tool libraries, gardens, parent cooperatives, and local networks.</li>
+        <li>Personal experiments with fewer notifications, more walking, shared meals, or scheduled community time.</li>
+      </ul>
+    </section>
+
+    <section>
+      <h2>What would change our minds?</h2>
+      <p>We should revise a Human Scale claim when better evidence shows that a proposed mismatch is not harmful, an intervention produces worse outcomes, a larger system protects flourishing better, or a cherished tradition creates more harm than benefit.</p>
+      <div class="callout">A doctrine becomes dangerous when preserving the doctrine becomes more important than understanding reality.</div>
+    </section>
+
+    <section class="closing">
+      <h2>The direction</h2>
+      <p>The purpose of studying human nature is not to imprison people in the past. It is to give the future a better design brief.</p>
+      <p>We can automate drudgery without automating meaning. We can use global knowledge while rebuilding local competence. We can protect freedom while making community easier.</p>
+      <strong>The goal is not to become primitive. The goal is to become compatible with ourselves.</strong>
+    </section>
+  </main>
+
+  <footer>
+    <a href="../index.html">Human Scale Doctrine</a> · <a href="../../index.html">tmsteph home</a><br />
+    Living framework · August 2026
+  </footer>
+</body>
+</html>

--- a/human-scale/index.html
+++ b/human-scale/index.html
@@ -204,6 +204,20 @@
       margin-bottom: 0;
     }
 
+    .chapter-link {
+      display: block;
+      margin-top: 1.4rem;
+      padding: 1.2rem 1.3rem;
+      border: 1px solid rgba(120, 200, 255, 0.3);
+      border-radius: 16px;
+      background: rgba(120, 200, 255, 0.06);
+      text-decoration: none;
+      color: var(--text);
+    }
+
+    .chapter-link strong { color: var(--sky); }
+    .chapter-link span { display: block; margin-top: 0.35rem; color: var(--muted); }
+
     .map {
       display: grid;
       grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
@@ -219,6 +233,8 @@
       color: #dceee1;
       text-align: center;
     }
+
+    .map a { color: inherit; text-decoration: none; }
 
     .questions {
       margin: 1.3rem 0 0;
@@ -268,7 +284,7 @@
 <body>
   <nav class="topbar" aria-label="Page navigation">
     <a href="../index.html">← tmsteph home</a>
-    <span>Living doctrine · v0.1</span>
+    <span>Living doctrine · v0.2</span>
   </nav>
 
   <header>
@@ -284,6 +300,18 @@
       <p>Human beings are biological organisms whose bodies and minds developed within nature, small communities, physical movement, direct relationships, seasonal rhythms, and meaningful dependence on the living world.</p>
       <p>Modern industrial civilization changed that environment at extraordinary speed.</p>
       <div class="callout">The problem is not that humanity learned too much. The problem is that our power to redesign the world grew faster than our understanding of what kind of world human beings actually need.</div>
+    </section>
+
+    <section>
+      <h2>A doctrine for living and changing the world</h2>
+      <p>This is not meant to be a collection of beliefs. It is meant to help people understand the systems around them, navigate daily life, and make those systems better.</p>
+      <div class="principles">
+        <div class="principle"><h3>Diagnosis</h3><p>What is happening? How did the system develop? What incentives, institutions, technologies, and environments shape the problem?</p></div>
+        <div class="principle"><h3>Field Guide</h3><p>How can a person, household, or small group live better inside the world that exists now?</p></div>
+        <div class="principle"><h3>Program</h3><p>What should communities, institutions, businesses, cities, and governments change or build?</p></div>
+      </div>
+      <div class="callout"><strong>understand → adapt → organize → reform → build alternatives</strong><br /><span class="muted">Self → Household → Neighborhood → Institutions → City & Region → Economy & Government → Civilization</span></div>
+      <a class="chapter-link" href="human-nature/index.html"><strong>Chapter 1: Human Nature — The Environment We Were Built For →</strong><span>The mismatch lens, a personal Field Guide, a Human Scale policy test, and a ladder from daily life to societal change.</span></a>
     </section>
 
     <section>
@@ -349,8 +377,14 @@
       <h2>Doctrine map</h2>
       <p class="muted">This is the beginning, not the finished system. Each branch can grow into principles, evidence, unanswered questions, and practical experiments.</p>
       <div class="map">
-        <div>Human Nature</div><div>Technology</div><div>Energy</div><div>Economics</div><div>Community</div><div>Education</div><div>Artificial Intelligence</div><div>Spirituality</div><div>Governance</div><div>Food & Agriculture</div><div>Architecture</div><div>Transportation</div><div>Work</div><div>Family</div><div>Health</div><div>Ecology</div><div>Open Source</div>
+        <div><a href="human-nature/index.html">Human Nature ↗</a></div><div>Technology</div><div>Energy</div><div>Economics</div><div>Community</div><div>Education</div><div>Artificial Intelligence</div><div>Spirituality</div><div>Governance</div><div>Food & Agriculture</div><div>Architecture</div><div>Transportation</div><div>Work</div><div>Family</div><div>Health</div><div>Ecology</div><div>Open Source</div>
       </div>
+    </section>
+
+    <section>
+      <h2>Evidence before dogma</h2>
+      <p>A serious doctrine should distinguish <strong>strong evidence</strong>, <strong>working hypotheses</strong>, <strong>value judgments</strong>, and <strong>political proposals</strong>.</p>
+      <div class="callout">A scientific finding does not automatically determine a political answer, and a political preference should not be disguised as scientific certainty. The doctrine should change when reality contradicts it.</div>
     </section>
 
     <section>
@@ -375,7 +409,7 @@
       <p>We can keep the knowledge. We can keep the science. We can keep the computers.</p>
       <p>And we can use them to build a civilization in which people once again belong to their bodies, their communities, and the Earth.</p>
       <strong>The village and the computer can coexist.</strong>
-      <p class="version">This is version 0.1 of a living doctrine. It is expected to change as the ideas are challenged, tested, refined, and expanded.</p>
+      <p class="version">This is version 0.2 of a living doctrine. It is expected to change as the ideas are challenged, tested, refined, and expanded.</p>
     </section>
   </main>
 


### PR DESCRIPTION
## What changed
- Added Chapter 1 of the Human Scale Doctrine: **Human Nature — The Environment We Were Built For**.
- Added a public mobile-friendly chapter page and a Markdown source-of-truth.
- Reworked the doctrine into **Diagnosis → Field Guide → Program**.
- Added the action cycle **understand → adapt → organize → reform → build alternatives**.
- Added an explicit ladder from personal action to societal change.
- Added evidence discipline so scientific claims, working hypotheses, value judgments, and political proposals are kept distinct.
- Linked the chapter directly from the Human Scale Doctrine page and doctrine map.

## Why
The doctrine is meant to help people navigate modern life and enact civic and societal change, not merely state beliefs. Human Nature provides the foundation for later chapters on technology, work, cities, food, AI, economics, governance, family, health, and community.

## Validation
- Branch is 4 commits ahead of `main` and 0 behind.
- Exactly four intended files changed.
- New chapter is standalone responsive HTML with a Markdown source copy.
- No application logic or existing unrelated pages were changed.