### PR TITLE
simplify Human Scale doctrine v0.3

### DIFF
--- a/human-scale/doctrine.md
+++ b/human-scale/doctrine.md
@@ -1,6 +1,6 @@
 # The Human Scale Doctrine
 
-**Version 0.2 — August 2026**
+**Version 0.3 — August 2026**
 
 > Humanity became powerful faster than it became wise.
 
@@ -12,33 +12,17 @@ Modern industrial civilization changed that environment at extraordinary speed.
 
 The problem is not that humanity learned too much. The problem is that our power to redesign the world grew faster than our understanding of what kind of world human beings actually need.
 
-## How to Use This Doctrine
+## What This Is For
 
-This doctrine is meant to help people do more than hold beliefs. It should help us understand the world, navigate it, and change it.
+This is not only a statement of belief. It should help us understand the world, live better inside it, and change the systems that work against human flourishing.
 
-Every major subject should eventually be developed in three layers:
+Each major subject can be approached through three simple questions:
 
-### Diagnosis
+1. **Diagnosis — What is happening, and why?**
+2. **Field Guide — What can people do now?**
+3. **Program — What should we change together?**
 
-What is happening? How did the current system develop? Which incentives, technologies, institutions, cultural habits, and physical environments shape the problem? Where does modern life conflict with recurring human needs?
-
-### Field Guide
-
-How can a person, family, or small group live better inside the world that exists now? What practical changes improve health, agency, competence, relationships, meaning, and resilience without requiring escape from society?
-
-### Program
-
-What should communities, institutions, businesses, cities, and governments change? Which reforms, technologies, public investments, ownership models, rules, and experiments could make human-compatible life easier for ordinary people?
-
-The doctrine should move repeatedly through the same cycle:
-
-**understand → adapt → organize → reform → build alternatives**
-
-And it should operate across a ladder of action:
-
-**Self → Household → Neighborhood → Institutions → City & Region → Economy & Government → Civilization**
-
-Higher-level change is not an excuse to neglect daily life. Personal adaptation is not an excuse to ignore structural problems.
+That is the structure. It is a tool for thinking, not a bureaucracy around the philosophy.
 
 ## The Wrong Turn
 
@@ -166,48 +150,25 @@ Science can tell us an extraordinary amount about how the world works.
 
 It does not eliminate the human need to ask what life is for.
 
-## Chapters
+## Chapter 1
 
-### 1. [Human Nature — The Environment We Were Built For](human-nature/index.html)
+### [Human Nature — The Environment We Were Built For](human-nature/index.html)
 
-The foundation of the doctrine. It introduces the mismatch lens, a practical Field Guide, a Human Scale policy test, and a ladder from personal action to societal change.
+The first long-form chapter explores the mismatch between recurring human needs and modern environments, then asks what individuals can do now and what communities or institutions might change.
 
-## Doctrine Map
+Long chapters are optional depth. The doctrine itself should remain readable without them.
 
-This project can grow into connected bodies of thought:
+## Where This Can Grow
 
-- [Human Nature](human-nature/index.html)
-- Technology
-- Energy
-- Economics
-- Community
-- Education
-- Artificial Intelligence
-- Spirituality
-- Governance
-- Food and Agriculture
-- Architecture
-- Transportation
-- Work
-- Family
-- Health
-- Ecology
-- Open Source
+Future subjects may include technology, energy, economics, community, education, artificial intelligence, spirituality, governance, food, architecture, transportation, work, family, health, ecology, and open source.
 
-Each branch should eventually contain principles, evidence, unanswered questions, and practical experiments.
+We do not need a complete system before we can learn, write, test ideas, or act.
 
-## Evidence Standard
+## One Rule for the Project
 
-A serious doctrine must distinguish between different kinds of claims:
+We should distinguish between **evidence**, **hypothesis**, **values**, and **political proposals**.
 
-- **Strong evidence** — supported across multiple methods, populations, or disciplines.
-- **Working hypothesis** — plausible and worth testing, but not settled.
-- **Value judgment** — a statement about the kind of life or society we consider desirable.
-- **Political proposal** — an intervention that must be evaluated for effectiveness, rights, cost, tradeoffs, unintended consequences, and public legitimacy.
-
-A scientific finding does not automatically determine a political answer, and a political preference should not be disguised as scientific certainty.
-
-The doctrine should be willing to change when reality contradicts it.
+We should be willing to say *we do not know*. We should test claims where we can. We should not disguise political preferences as scientific certainty. And when reality contradicts the doctrine, the doctrine should change.
 
 ## Open Questions
 
@@ -215,7 +176,7 @@ This doctrine is intentionally unfinished.
 
 Among the questions still to explore:
 
-- Which parts of modern life create the greatest evolutionary mismatch?
+- Which parts of modern life create the greatest mismatch with human nature?
 - Which technologies measurably improve human flourishing?
 - What is the ideal scale for different institutions?
 - How much localization is resilient without becoming isolationist?

--- a/human-scale/index.html
+++ b/human-scale/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>The Human Scale Doctrine — Thomas Stephens</title>
-  <meta name="description" content="A living doctrine about human nature, technology, energy, community, ecology, and building civilization around human flourishing." />
+  <meta name="description" content="A living doctrine for understanding modern life, living more humanly, and building a civilization around human flourishing." />
   <meta name="theme-color" content="#07111f" />
   <link rel="icon" href="../favicon.ico" type="image/x-icon" />
   <style>
@@ -12,17 +12,14 @@
       color-scheme: dark;
       --bg: #07111f;
       --panel: #0b1728;
-      --panel-soft: #102037;
       --text: #e8eef7;
       --muted: #a9b8cb;
       --line: #22344c;
       --sky: #78c8ff;
       --sun: #ffe28a;
-      --green: #9ed8aa;
     }
 
     * { box-sizing: border-box; }
-
     html { scroll-behavior: smooth; }
 
     body {
@@ -39,139 +36,144 @@
     a { color: var(--sky); }
 
     .topbar {
-      max-width: 1100px;
+      max-width: 1050px;
       margin: 0 auto;
-      padding: 1.25rem 1.5rem 0;
+      padding: 1.25rem 1.4rem 0;
       display: flex;
       justify-content: space-between;
       gap: 1rem;
-      align-items: center;
       color: var(--muted);
-      font-size: 0.95rem;
+      font-size: 0.92rem;
     }
 
-    .topbar a {
-      text-decoration: none;
-      color: var(--muted);
-    }
-
+    .topbar a { color: var(--muted); text-decoration: none; }
     .topbar a:hover { color: var(--text); }
 
     header {
-      max-width: 980px;
+      max-width: 900px;
       margin: 0 auto;
-      padding: 7rem 1.5rem 5rem;
+      padding: 6.5rem 1.4rem 4.5rem;
       text-align: center;
     }
 
     .eyebrow {
-      text-transform: uppercase;
-      letter-spacing: 0.16em;
+      color: var(--sky);
       font-size: 0.78rem;
       font-weight: 800;
-      color: var(--sky);
+      letter-spacing: 0.16em;
+      text-transform: uppercase;
     }
 
     h1 {
-      margin: 0.7rem 0 1rem;
-      font-size: clamp(3rem, 9vw, 6.5rem);
-      line-height: 0.96;
+      margin: 0.75rem 0 1.1rem;
+      font-size: clamp(3rem, 9vw, 6rem);
+      line-height: 0.97;
       letter-spacing: -0.055em;
-    }
-
-    .lead {
-      margin: 1.5rem auto 0;
-      max-width: 760px;
-      color: var(--muted);
-      font-size: clamp(1.12rem, 2.6vw, 1.4rem);
-    }
-
-    .thesis {
-      max-width: 830px;
-      margin: 2.5rem auto 0;
-      padding: 1.4rem 1.6rem;
-      border: 1px solid rgba(255, 226, 138, 0.28);
-      border-radius: 18px;
-      background: rgba(255, 226, 138, 0.055);
-      color: #fff4cf;
-      font-size: clamp(1.25rem, 3vw, 1.75rem);
-      font-weight: 750;
-    }
-
-    main {
-      width: min(100% - 2rem, 920px);
-      margin: 0 auto;
-      padding-bottom: 6rem;
-    }
-
-    section {
-      padding: 3.3rem 0;
-      border-top: 1px solid var(--line);
     }
 
     h2 {
       margin: 0 0 1rem;
-      font-size: clamp(1.9rem, 5vw, 3rem);
-      letter-spacing: -0.035em;
+      font-size: clamp(1.9rem, 5vw, 2.8rem);
       line-height: 1.08;
+      letter-spacing: -0.035em;
     }
 
-    h3 {
-      margin: 0;
-      font-size: 1.15rem;
-      line-height: 1.3;
-      color: #f4f8fc;
-    }
-
+    h3 { margin: 0; font-size: 1.12rem; line-height: 1.3; }
     p { margin: 0.9rem 0; }
+
+    .lead {
+      max-width: 720px;
+      margin: 0 auto;
+      color: var(--muted);
+      font-size: clamp(1.08rem, 2.6vw, 1.35rem);
+    }
+
+    .thesis {
+      max-width: 780px;
+      margin: 2.3rem auto 0;
+      padding: 1.35rem 1.5rem;
+      border: 1px solid rgba(255, 226, 138, 0.28);
+      border-radius: 18px;
+      background: rgba(255, 226, 138, 0.055);
+      color: #fff4cf;
+      font-size: clamp(1.25rem, 3vw, 1.7rem);
+      font-weight: 750;
+    }
+
+    main {
+      width: min(100% - 2rem, 880px);
+      margin: 0 auto;
+      padding-bottom: 5rem;
+    }
+
+    section {
+      padding: 3.1rem 0;
+      border-top: 1px solid var(--line);
+    }
 
     .muted { color: var(--muted); }
 
     .callout {
-      margin: 2rem 0 0;
-      padding: 1.4rem 1.5rem;
+      margin: 1.7rem 0 0;
+      padding: 1.3rem 1.4rem;
       border-left: 4px solid var(--sky);
       border-radius: 0 14px 14px 0;
       background: var(--panel);
-      font-size: 1.14rem;
+      font-size: 1.1rem;
     }
+
+    .three {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 1rem;
+      margin-top: 1.5rem;
+    }
+
+    .card {
+      padding: 1.2rem;
+      border: 1px solid var(--line);
+      border-radius: 16px;
+      background: var(--panel);
+    }
+
+    .card p { margin-bottom: 0; color: var(--muted); }
 
     .needs {
       display: flex;
       flex-wrap: wrap;
-      gap: 0.65rem;
-      margin: 1.5rem 0 0;
+      gap: 0.6rem;
       padding: 0;
+      margin: 1.4rem 0;
       list-style: none;
     }
 
     .needs li {
+      padding: 0.42rem 0.75rem;
       border: 1px solid var(--line);
       border-radius: 999px;
-      padding: 0.45rem 0.8rem;
       background: rgba(255,255,255,0.025);
       color: #dbe6f3;
     }
 
     .theses {
       display: grid;
-      gap: 1rem;
-      margin-top: 1.7rem;
+      gap: 0.9rem;
+      margin-top: 1.5rem;
     }
 
     .thesis-card {
       display: grid;
-      grid-template-columns: 3rem 1fr;
+      grid-template-columns: 2.7rem 1fr;
       gap: 1rem;
-      padding: 1.2rem;
+      padding: 1.15rem;
       border: 1px solid var(--line);
       border-radius: 16px;
       background: linear-gradient(145deg, rgba(16,32,55,0.82), rgba(8,19,34,0.82));
     }
 
-    .thesis-number {
-      width: 3rem;
-      height: 3rem;
+    .number {
+      width: 2.7rem;
+      height: 2.7rem;
       display: grid;
       place-items: center;
       border-radius: 50%;
@@ -180,117 +182,61 @@
       font-weight: 850;
     }
 
-    .thesis-card p {
-      margin: 0.45rem 0 0;
-      color: var(--muted);
-    }
+    .thesis-card p { margin: 0.4rem 0 0; color: var(--muted); }
 
-    .principles {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
-      gap: 1rem;
-      margin-top: 1.4rem;
-    }
-
-    .principle {
-      padding: 1.25rem;
-      border: 1px solid var(--line);
-      border-radius: 16px;
-      background: var(--panel);
-    }
-
-    .principle p {
-      color: var(--muted);
-      margin-bottom: 0;
-    }
-
-    .chapter-link {
+    .chapter {
       display: block;
+      padding: 1.4rem;
       margin-top: 1.4rem;
-      padding: 1.2rem 1.3rem;
       border: 1px solid rgba(120, 200, 255, 0.3);
       border-radius: 16px;
       background: rgba(120, 200, 255, 0.06);
-      text-decoration: none;
       color: var(--text);
+      text-decoration: none;
     }
 
-    .chapter-link strong { color: var(--sky); }
-    .chapter-link span { display: block; margin-top: 0.35rem; color: var(--muted); }
+    .chapter strong { color: var(--sky); font-size: 1.08rem; }
+    .chapter span { display: block; margin-top: 0.4rem; color: var(--muted); }
 
-    .map {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-      gap: 0.75rem;
-      margin-top: 1.4rem;
-    }
-
-    .map div {
-      padding: 0.9rem 1rem;
-      border-radius: 12px;
-      border: 1px solid var(--line);
-      background: rgba(158, 216, 170, 0.04);
-      color: #dceee1;
-      text-align: center;
-    }
-
-    .map a { color: inherit; text-decoration: none; }
-
-    .questions {
-      margin: 1.3rem 0 0;
-      padding-left: 1.25rem;
-      color: var(--muted);
-    }
-
-    .questions li { margin: 0.65rem 0; }
-
-    .closing {
-      text-align: center;
-      padding-bottom: 1rem;
-    }
+    .closing { text-align: center; }
 
     .closing strong {
       display: block;
+      max-width: 720px;
       margin: 2rem auto 0;
-      max-width: 760px;
       color: var(--sun);
-      font-size: clamp(1.65rem, 5vw, 2.65rem);
+      font-size: clamp(1.6rem, 5vw, 2.5rem);
       line-height: 1.15;
       letter-spacing: -0.035em;
     }
 
-    .version {
-      margin-top: 2rem;
-      color: var(--muted);
-      font-size: 0.92rem;
-    }
+    .version { margin-top: 2rem; color: var(--muted); font-size: 0.9rem; }
 
     footer {
+      padding: 2.5rem 1.4rem 3.5rem;
       border-top: 1px solid var(--line);
-      color: var(--muted);
       text-align: center;
-      padding: 2.5rem 1.5rem 3.5rem;
+      color: var(--muted);
     }
 
     footer a { text-decoration: none; }
 
-    @media (max-width: 620px) {
+    @media (max-width: 700px) {
       header { padding-top: 5rem; }
-      .thesis-card { grid-template-columns: 2.5rem 1fr; }
-      .thesis-number { width: 2.5rem; height: 2.5rem; }
+      .three { grid-template-columns: 1fr; }
     }
   </style>
 </head>
 <body>
   <nav class="topbar" aria-label="Page navigation">
     <a href="../index.html">← tmsteph home</a>
-    <span>Living doctrine · v0.2</span>
+    <span>Living doctrine · v0.3</span>
   </nav>
 
   <header>
     <div class="eyebrow">Thomas Stephens · August 2026</div>
     <h1>The Human Scale Doctrine</h1>
-    <p class="lead">A living framework about human nature, technology, energy, community, ecology, and the kind of civilization worth building.</p>
+    <p class="lead">A living framework for understanding modern life, living more humanly, and building a civilization around human flourishing.</p>
     <div class="thesis">Humanity became powerful faster than it became wise.</div>
   </header>
 
@@ -303,15 +249,13 @@
     </section>
 
     <section>
-      <h2>A doctrine for living and changing the world</h2>
-      <p>This is not meant to be a collection of beliefs. It is meant to help people understand the systems around them, navigate daily life, and make those systems better.</p>
-      <div class="principles">
-        <div class="principle"><h3>Diagnosis</h3><p>What is happening? How did the system develop? What incentives, institutions, technologies, and environments shape the problem?</p></div>
-        <div class="principle"><h3>Field Guide</h3><p>How can a person, household, or small group live better inside the world that exists now?</p></div>
-        <div class="principle"><h3>Program</h3><p>What should communities, institutions, businesses, cities, and governments change or build?</p></div>
+      <h2>What this is for</h2>
+      <p>This is not only a statement of belief. It should help us understand the world, live better inside it, and change the systems that work against human flourishing.</p>
+      <div class="three">
+        <div class="card"><h3>Diagnosis</h3><p>What is happening, and why?</p></div>
+        <div class="card"><h3>Field Guide</h3><p>What can people do now?</p></div>
+        <div class="card"><h3>Program</h3><p>What should we change together?</p></div>
       </div>
-      <div class="callout"><strong>understand → adapt → organize → reform → build alternatives</strong><br /><span class="muted">Self → Household → Neighborhood → Institutions → City & Region → Economy & Government → Civilization</span></div>
-      <a class="chapter-link" href="human-nature/index.html"><strong>Chapter 1: Human Nature — The Environment We Were Built For →</strong><span>The mismatch lens, a personal Field Guide, a Human Scale policy test, and a ladder from daily life to societal change.</span></a>
     </section>
 
     <section>
@@ -334,82 +278,50 @@
     <section>
       <h2>Ten theses</h2>
       <div class="theses">
-        <article class="thesis-card"><div class="thesis-number">1</div><div><h3>Human beings are biological organisms, not abstract economic units.</h3><p>Durable systems must begin with the realities of the body, mind, relationships, and ecology.</p></div></article>
-        <article class="thesis-card"><div class="thesis-number">2</div><div><h3>Our biology changes more slowly than our technological environment.</h3><p>Civilization can therefore become materially advanced while creating psychologically or physically hostile conditions.</p></div></article>
-        <article class="thesis-card"><div class="thesis-number">3</div><div><h3>Fossil energy accelerated the mismatch.</h3><p>It allowed human environments, institutions, and consumption patterns to transform at a speed previously impossible.</p></div></article>
-        <article class="thesis-card"><div class="thesis-number">4</div><div><h3>Efficiency is not the same as flourishing.</h3><p>A system can produce more, move faster, and generate more profit while making everyday life worse.</p></div></article>
-        <article class="thesis-card"><div class="thesis-number">5</div><div><h3>Technology is a tool, not a destiny.</h3><p>We are allowed to decide which technologies deserve a place in human life and under what conditions.</p></div></article>
-        <article class="thesis-card"><div class="thesis-number">6</div><div><h3>Human-scale systems should be preferred when they work.</h3><p>Local food, walkable places, small groups, repairable tools, distributed production, and understandable institutions often preserve agency and resilience.</p></div></article>
-        <article class="thesis-card"><div class="thesis-number">7</div><div><h3>Advanced technology should become quieter.</h3><p>The best machines should remove drudgery and bureaucracy without consuming human attention, identity, and purpose.</p></div></article>
-        <article class="thesis-card"><div class="thesis-number">8</div><div><h3>Open systems protect human agency.</h3><p>Knowledge, software, hardware, protocols, and infrastructure should be understandable, repairable, interoperable, and shareable whenever possible.</p></div></article>
-        <article class="thesis-card"><div class="thesis-number">9</div><div><h3>Ecology is not an externality.</h3><p>Human civilization exists inside the living world. Damage to soil, water, air, climate, biodiversity, and ecosystems eventually becomes damage to human life.</p></div></article>
-        <article class="thesis-card"><div class="thesis-number">10</div><div><h3>Recover what modernity discarded without discarding what humanity learned.</h3><p>We do not need to choose between the village and the computer. We can build both.</p></div></article>
+        <article class="thesis-card"><div class="number">1</div><div><h3>Human beings are biological organisms, not abstract economic units.</h3><p>Durable systems must begin with the realities of the body, mind, relationships, and ecology.</p></div></article>
+        <article class="thesis-card"><div class="number">2</div><div><h3>Our biology changes more slowly than our technological environment.</h3><p>Material advancement can still create psychologically or physically hostile conditions.</p></div></article>
+        <article class="thesis-card"><div class="number">3</div><div><h3>Fossil energy accelerated the mismatch.</h3><p>Human environments and institutions could transform at a speed previously impossible.</p></div></article>
+        <article class="thesis-card"><div class="number">4</div><div><h3>Efficiency is not the same as flourishing.</h3><p>A system can produce more and move faster while making everyday life worse.</p></div></article>
+        <article class="thesis-card"><div class="number">5</div><div><h3>Technology is a tool, not a destiny.</h3><p>We can decide which technologies deserve a place in human life and under what conditions.</p></div></article>
+        <article class="thesis-card"><div class="number">6</div><div><h3>Human-scale systems should be preferred when they work.</h3><p>Local, understandable, repairable systems often preserve agency and resilience.</p></div></article>
+        <article class="thesis-card"><div class="number">7</div><div><h3>Advanced technology should become quieter.</h3><p>The best machines remove drudgery without consuming attention, identity, and purpose.</p></div></article>
+        <article class="thesis-card"><div class="number">8</div><div><h3>Open systems protect human agency.</h3><p>Knowledge and infrastructure should be understandable, repairable, interoperable, and shareable whenever possible.</p></div></article>
+        <article class="thesis-card"><div class="number">9</div><div><h3>Ecology is not an externality.</h3><p>Human civilization exists inside the living world, not outside it.</p></div></article>
+        <article class="thesis-card"><div class="number">10</div><div><h3>Recover what modernity discarded without discarding what humanity learned.</h3><p>We do not need to choose between the village and the computer. We can build both.</p></div></article>
       </div>
     </section>
 
     <section>
       <h2>What progress should mean</h2>
-      <p>Progress should not be measured only by GDP, speed, scale, convenience, or computational power.</p>
-      <div class="principles">
-        <div class="principle"><h3>Healthy bodies</h3><p>Movement, sleep, nourishment, sunlight, clean air, and environments that support physical life.</p></div>
-        <div class="principle"><h3>Deep relationships</h3><p>Time with family, friends, children, neighbors, and communities that know one another.</p></div>
-        <div class="principle"><h3>Agency</h3><p>People should be able to understand and influence the systems that shape their lives.</p></div>
-        <div class="principle"><h3>Meaning</h3><p>Work, creativity, service, spirituality, learning, and participation in something larger than consumption.</p></div>
-        <div class="principle"><h3>Ecological continuity</h3><p>The world inherited by the next generation should remain capable of sustaining abundant life.</p></div>
-        <div class="principle"><h3>Time</h3><p>A wealthy civilization should return time to people, not merely fill every minute with more production and stimulation.</p></div>
-      </div>
+      <p>Progress is more than GDP, speed, scale, convenience, or computational power. A civilization is progressing when people have healthier bodies, deeper relationships, meaningful work, time, agency, access to nature, material security, room to create, and a living world to pass on.</p>
     </section>
 
     <section>
-      <h2>The technological direction</h2>
-      <p>This doctrine is not anti-technology. It argues for <strong>human-compatible technology</strong>: renewable and locally resilient energy, open-source software and hardware, distributed networks, repairable devices, flexible manufacturing, automation of dangerous and bureaucratic labor, humane AI, and computing that can disappear into the background when it is not needed.</p>
+      <h2>The direction</h2>
+      <p><strong>Technology:</strong> open, repairable, distributed, resilient, and quiet enough to disappear when it is not needed.</p>
+      <p><strong>Society:</strong> stronger families and communities, meaningful public space, local ownership where it works, pluralism, and power that stays understandable and accountable.</p>
+      <p><strong>Inner life:</strong> room for science and reason alongside prayer, meditation, art, music, philosophy, nature, and the human search for meaning.</p>
       <div class="callout">The goal is not maximum technology. The goal is the right technology in the right place, serving life.</div>
     </section>
 
     <section>
-      <h2>The social and spiritual direction</h2>
-      <p>Human-scale civilization should make it easier to form durable communities without forcing everyone into one ideology or lifestyle. It should favor strong families and chosen families, voluntary associations, mutual aid, local ownership, cooperative creation, public space, decentralized power, cultural pluralism, freedom of belief, and room for spiritual life.</p>
-      <p>Human beings have always searched for meaning. A humane civilization should make room for contemplation, ritual, prayer, meditation, art, music, mystery, philosophy, and direct encounters with nature without demanding one metaphysical explanation from everyone.</p>
-      <p class="muted">Science can tell us an extraordinary amount about how the world works. It does not eliminate the human need to ask what life is for.</p>
+      <h2>Go deeper</h2>
+      <p>The doctrine should remain readable on its own. Longer chapters are optional depth, not prerequisites.</p>
+      <a class="chapter" href="human-nature/index.html"><strong>Chapter 1: Human Nature — The Environment We Were Built For →</strong><span>How recurring human needs collide with modern environments, what we can do personally, and what we may want to change together.</span></a>
     </section>
 
     <section>
-      <h2>Doctrine map</h2>
-      <p class="muted">This is the beginning, not the finished system. Each branch can grow into principles, evidence, unanswered questions, and practical experiments.</p>
-      <div class="map">
-        <div><a href="human-nature/index.html">Human Nature ↗</a></div><div>Technology</div><div>Energy</div><div>Economics</div><div>Community</div><div>Education</div><div>Artificial Intelligence</div><div>Spirituality</div><div>Governance</div><div>Food & Agriculture</div><div>Architecture</div><div>Transportation</div><div>Work</div><div>Family</div><div>Health</div><div>Ecology</div><div>Open Source</div>
-      </div>
-    </section>
-
-    <section>
-      <h2>Evidence before dogma</h2>
-      <p>A serious doctrine should distinguish <strong>strong evidence</strong>, <strong>working hypotheses</strong>, <strong>value judgments</strong>, and <strong>political proposals</strong>.</p>
-      <div class="callout">A scientific finding does not automatically determine a political answer, and a political preference should not be disguised as scientific certainty. The doctrine should change when reality contradicts it.</div>
-    </section>
-
-    <section>
-      <h2>Open questions</h2>
-      <ul class="questions">
-        <li>Which parts of modern life create the greatest mismatch with human nature?</li>
-        <li>Which technologies measurably improve human flourishing?</li>
-        <li>What is the ideal scale for different institutions?</li>
-        <li>How much localization creates resilience without becoming isolation?</li>
-        <li>How should ownership change in a highly automated economy?</li>
-        <li>What work should humans continue doing even when machines can do it?</li>
-        <li>How can dense cities become deeply connected to nature?</li>
-        <li>How do we preserve scientific rigor while allowing spiritual pluralism?</li>
-        <li>What should children learn in a civilization built around human flourishing?</li>
-        <li>How should AI be designed if attention, agency, and human development are primary values?</li>
-      </ul>
+      <h2>One rule for the project</h2>
+      <p>We should distinguish evidence from hypothesis, values, and political proposals. We should be willing to say <em>we do not know</em>, test ideas where we can, and change the doctrine when reality contradicts it.</p>
     </section>
 
     <section class="closing">
-      <h2>The direction</h2>
+      <h2>The future</h2>
       <p>The future does not need to be a choice between technological acceleration and a romantic return to the past.</p>
       <p>We can keep the knowledge. We can keep the science. We can keep the computers.</p>
       <p>And we can use them to build a civilization in which people once again belong to their bodies, their communities, and the Earth.</p>
       <strong>The village and the computer can coexist.</strong>
-      <p class="version">This is version 0.2 of a living doctrine. It is expected to change as the ideas are challenged, tested, refined, and expanded.</p>
+      <p class="version">Version 0.3 · A living doctrine, expected to change as its ideas are challenged, tested, and refined.</p>
     </section>
   </main>
 


### PR DESCRIPTION
## What changed
- Simplified the Human Scale Doctrine to preserve the stronger manifesto voice while keeping the practical purpose.
- Kept **Diagnosis → Field Guide → Program** as the only reader-facing framework.
- Removed the extra action-cycle and scale-ladder framework from the main doctrine.
- Shortened the public doctrine page substantially and made Chapter 1 explicitly optional depth.
- Kept a concise evidence rule: distinguish evidence, hypotheses, values, and political proposals, and change the doctrine when reality contradicts it.

## Why
The doctrine was starting to accumulate too many frameworks. v0.3 keeps the substance and practical mission while making the main page easier to understand and actually read.

## Validation
- Branch is 2 commits ahead of `main` and 0 behind.
- Exactly two files changed: `human-scale/doctrine.md` and `human-scale/index.html`.
- Net simplification: the doctrine Markdown removes more lines than it adds, and the public page removes substantial structural clutter.
- Chapter 1 remains intact and linked as optional long-form depth.