### PR TITLE
add Land & Life chapter

### DIFF
--- a/human-scale/doctrine.md
+++ b/human-scale/doctrine.md
@@ -1,6 +1,6 @@
 # The Human Scale Doctrine
 
-**Version 0.3 — August 2026**
+**Version 0.4 — August 2026**
 
 > Humanity became powerful faster than it became wise.
 
@@ -94,6 +94,7 @@ A civilization is progressing when more people can:
 - create rather than merely consume
 - work without surrendering their entire waking lives
 - access nature and public space
+- participate directly in the living world through soil, plants, food, animals, and stewardship
 - obtain food, shelter, education, and healthcare without permanent desperation
 - participate in culture and community
 - develop spiritually, intellectually, emotionally, and creatively
@@ -133,6 +134,7 @@ It should favor:
 - local ownership
 - cooperative creation
 - meaningful public spaces
+- meaningful access to living land
 - decentralized political and economic power
 - cultural pluralism
 - freedom of belief
@@ -144,17 +146,21 @@ Large systems will still exist. The principle is that scale should have to justi
 
 Human beings have always searched for meaning.
 
-A humane civilization should make room for contemplation, ritual, prayer, meditation, art, music, mystery, philosophy, and direct encounters with nature without demanding one metaphysical explanation from everyone.
+A humane civilization should make room for contemplation, ritual, prayer, meditation, yoga, art, music, mystery, philosophy, direct encounters with nature, and other practices that bring people back into body, place, relationship, and immediate experience without demanding one metaphysical explanation from everyone.
 
 Science can tell us an extraordinary amount about how the world works.
 
 It does not eliminate the human need to ask what life is for.
 
-## Chapter 1
+## Chapters
 
-### [Human Nature — The Environment We Were Built For](human-nature/index.html)
+### 1. [Human Nature — The Environment We Were Built For](human-nature/index.html)
 
 The first long-form chapter explores the mismatch between recurring human needs and modern environments, then asks what individuals can do now and what communities or institutions might change.
+
+### 2. [Land & Life — Reconnecting Humans to the Living World](land-life/index.html)
+
+The second chapter argues that meaningful access to soil, plants, animals, gardens, food forests, open sky, and embodied practices should be part of ordinary life rather than a luxury. It explores both personal participation and public design.
 
 Long chapters are optional depth. The doctrine itself should remain readable without them.
 
@@ -180,6 +186,7 @@ Among the questions still to explore:
 - Which technologies measurably improve human flourishing?
 - What is the ideal scale for different institutions?
 - How much localization is resilient without becoming isolationist?
+- How can land access be expanded without pretending ownership, housing, farming, ecology, and public access have no tradeoffs?
 - How should ownership change in a highly automated economy?
 - What work should humans continue doing even when machines can do it?
 - How can dense cities become deeply connected to nature?

--- a/human-scale/index.html
+++ b/human-scale/index.html
@@ -18,10 +18,8 @@
       --sky: #78c8ff;
       --sun: #ffe28a;
     }
-
     * { box-sizing: border-box; }
     html { scroll-behavior: smooth; }
-
     body {
       margin: 0;
       font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
@@ -32,9 +30,7 @@
       color: var(--text);
       line-height: 1.72;
     }
-
     a { color: var(--sky); }
-
     .topbar {
       max-width: 1050px;
       margin: 0 auto;
@@ -45,17 +41,14 @@
       color: var(--muted);
       font-size: 0.92rem;
     }
-
     .topbar a { color: var(--muted); text-decoration: none; }
     .topbar a:hover { color: var(--text); }
-
     header {
       max-width: 900px;
       margin: 0 auto;
       padding: 6.5rem 1.4rem 4.5rem;
       text-align: center;
     }
-
     .eyebrow {
       color: var(--sky);
       font-size: 0.78rem;
@@ -63,31 +56,26 @@
       letter-spacing: 0.16em;
       text-transform: uppercase;
     }
-
     h1 {
       margin: 0.75rem 0 1.1rem;
       font-size: clamp(3rem, 9vw, 6rem);
       line-height: 0.97;
       letter-spacing: -0.055em;
     }
-
     h2 {
       margin: 0 0 1rem;
       font-size: clamp(1.9rem, 5vw, 2.8rem);
       line-height: 1.08;
       letter-spacing: -0.035em;
     }
-
     h3 { margin: 0; font-size: 1.12rem; line-height: 1.3; }
     p { margin: 0.9rem 0; }
-
     .lead {
       max-width: 720px;
       margin: 0 auto;
       color: var(--muted);
       font-size: clamp(1.08rem, 2.6vw, 1.35rem);
     }
-
     .thesis {
       max-width: 780px;
       margin: 2.3rem auto 0;
@@ -99,20 +87,16 @@
       font-size: clamp(1.25rem, 3vw, 1.7rem);
       font-weight: 750;
     }
-
     main {
       width: min(100% - 2rem, 880px);
       margin: 0 auto;
       padding-bottom: 5rem;
     }
-
     section {
       padding: 3.1rem 0;
       border-top: 1px solid var(--line);
     }
-
     .muted { color: var(--muted); }
-
     .callout {
       margin: 1.7rem 0 0;
       padding: 1.3rem 1.4rem;
@@ -121,23 +105,19 @@
       background: var(--panel);
       font-size: 1.1rem;
     }
-
     .three {
       display: grid;
       grid-template-columns: repeat(3, 1fr);
       gap: 1rem;
       margin-top: 1.5rem;
     }
-
     .card {
       padding: 1.2rem;
       border: 1px solid var(--line);
       border-radius: 16px;
       background: var(--panel);
     }
-
     .card p { margin-bottom: 0; color: var(--muted); }
-
     .needs {
       display: flex;
       flex-wrap: wrap;
@@ -146,7 +126,6 @@
       margin: 1.4rem 0;
       list-style: none;
     }
-
     .needs li {
       padding: 0.42rem 0.75rem;
       border: 1px solid var(--line);
@@ -154,13 +133,11 @@
       background: rgba(255,255,255,0.025);
       color: #dbe6f3;
     }
-
     .theses {
       display: grid;
       gap: 0.9rem;
       margin-top: 1.5rem;
     }
-
     .thesis-card {
       display: grid;
       grid-template-columns: 2.7rem 1fr;
@@ -170,7 +147,6 @@
       border-radius: 16px;
       background: linear-gradient(145deg, rgba(16,32,55,0.82), rgba(8,19,34,0.82));
     }
-
     .number {
       width: 2.7rem;
       height: 2.7rem;
@@ -181,25 +157,20 @@
       color: var(--sky);
       font-weight: 850;
     }
-
     .thesis-card p { margin: 0.4rem 0 0; color: var(--muted); }
-
     .chapter {
       display: block;
       padding: 1.4rem;
-      margin-top: 1.4rem;
+      margin-top: 1rem;
       border: 1px solid rgba(120, 200, 255, 0.3);
       border-radius: 16px;
       background: rgba(120, 200, 255, 0.06);
       color: var(--text);
       text-decoration: none;
     }
-
     .chapter strong { color: var(--sky); font-size: 1.08rem; }
     .chapter span { display: block; margin-top: 0.4rem; color: var(--muted); }
-
     .closing { text-align: center; }
-
     .closing strong {
       display: block;
       max-width: 720px;
@@ -209,18 +180,14 @@
       line-height: 1.15;
       letter-spacing: -0.035em;
     }
-
     .version { margin-top: 2rem; color: var(--muted); font-size: 0.9rem; }
-
     footer {
       padding: 2.5rem 1.4rem 3.5rem;
       border-top: 1px solid var(--line);
       text-align: center;
       color: var(--muted);
     }
-
     footer a { text-decoration: none; }
-
     @media (max-width: 700px) {
       header { padding-top: 5rem; }
       .three { grid-template-columns: 1fr; }
@@ -230,7 +197,7 @@
 <body>
   <nav class="topbar" aria-label="Page navigation">
     <a href="../index.html">← tmsteph home</a>
-    <span>Living doctrine · v0.3</span>
+    <span>Living doctrine · v0.4</span>
   </nav>
 
   <header>
@@ -293,14 +260,14 @@
 
     <section>
       <h2>What progress should mean</h2>
-      <p>Progress is more than GDP, speed, scale, convenience, or computational power. A civilization is progressing when people have healthier bodies, deeper relationships, meaningful work, time, agency, access to nature, material security, room to create, and a living world to pass on.</p>
+      <p>Progress is more than GDP, speed, scale, convenience, or computational power. A civilization is progressing when people have healthier bodies, deeper relationships, meaningful work, time, agency, access to nature and living land, material security, room to create, and a living world to pass on.</p>
     </section>
 
     <section>
       <h2>The direction</h2>
       <p><strong>Technology:</strong> open, repairable, distributed, resilient, and quiet enough to disappear when it is not needed.</p>
-      <p><strong>Society:</strong> stronger families and communities, meaningful public space, local ownership where it works, pluralism, and power that stays understandable and accountable.</p>
-      <p><strong>Inner life:</strong> room for science and reason alongside prayer, meditation, art, music, philosophy, nature, and the human search for meaning.</p>
+      <p><strong>Society:</strong> stronger families and communities, meaningful public space, access to living land, local ownership where it works, pluralism, and power that stays understandable and accountable.</p>
+      <p><strong>Inner life:</strong> room for science and reason alongside prayer, meditation, yoga, art, music, philosophy, nature, and the human search for meaning.</p>
       <div class="callout">The goal is not maximum technology. The goal is the right technology in the right place, serving life.</div>
     </section>
 
@@ -308,6 +275,7 @@
       <h2>Go deeper</h2>
       <p>The doctrine should remain readable on its own. Longer chapters are optional depth, not prerequisites.</p>
       <a class="chapter" href="human-nature/index.html"><strong>Chapter 1: Human Nature — The Environment We Were Built For →</strong><span>How recurring human needs collide with modern environments, what we can do personally, and what we may want to change together.</span></a>
+      <a class="chapter" href="land-life/index.html"><strong>Chapter 2: Land & Life — Reconnecting Humans to the Living World →</strong><span>Land access, gardens, food forests, plants, animals, embodied practice, and the idea that living systems belong inside everyday infrastructure.</span></a>
     </section>
 
     <section>
@@ -321,7 +289,7 @@
       <p>We can keep the knowledge. We can keep the science. We can keep the computers.</p>
       <p>And we can use them to build a civilization in which people once again belong to their bodies, their communities, and the Earth.</p>
       <strong>The village and the computer can coexist.</strong>
-      <p class="version">Version 0.3 · A living doctrine, expected to change as its ideas are challenged, tested, and refined.</p>
+      <p class="version">Version 0.4 · A living doctrine, expected to change as its ideas are challenged, tested, and refined.</p>
     </section>
   </main>
 

--- a/human-scale/land-life/chapter.md
+++ b/human-scale/land-life/chapter.md
@@ -1,0 +1,308 @@
+# Chapter 2: Land & Life — Reconnecting Humans to the Living World
+
+**Human Scale Doctrine — Diagnosis / Field Guide / Program**
+
+> Humans do not only need to look at nature. We need ways to participate in the living world.
+
+Modern life often treats land as scenery, real estate, or a resource to be extracted. Food arrives packaged. Water arrives through pipes. Waste disappears into systems most people never see. Plants become decoration. Animals become pets, products, pests, or distant wildlife.
+
+The Human Scale view is different.
+
+Human beings are part of an ecological world. We depend on soil, water, plants, animals, fungi, insects, microbes, sunlight, weather, and seasons whether or not modern systems make those relationships visible.
+
+A healthier civilization should make those relationships easier to experience directly.
+
+That does not mean everyone must become a farmer or live in the countryside. It means that **access to living land should not be a luxury reserved for people wealthy enough to buy rural property.**
+
+Every person should have meaningful opportunities to touch soil, grow food, care for plants or animals, spend time under open sky, and participate in places where life is actively growing.
+
+---
+
+# Part I — Diagnosis
+
+## 1. Nature became something we visit
+
+Industrial civilization has made it possible for millions of people to live almost entirely inside built systems.
+
+A person can wake indoors, travel inside a vehicle, work indoors, buy food grown far away, exercise indoors, relax through a screen, and go to sleep without directly interacting with soil, plants, animals, or the processes that sustain life.
+
+This is extraordinary in one sense. It frees people from many forms of dangerous and exhausting labor.
+
+But something can be gained and lost at the same time.
+
+When the living world becomes invisible, people can become dependent on ecological systems they barely understand and emotionally detached from damage occurring inside them.
+
+Nature becomes a destination instead of a relationship.
+
+## 2. Land became primarily property
+
+Private property can protect independence, stability, stewardship, and personal freedom.
+
+But when nearly every useful piece of land is accessible only through ownership, rent, or commercial permission, people without wealth may have very little ability to participate in land at all.
+
+The Human Scale Doctrine therefore distinguishes **ownership** from **access**.
+
+Everyone does not need to own acres of land.
+
+Everyone should have realistic access to some combination of:
+
+- gardens
+- community growing space
+- trees and shade
+- edible landscapes
+- parks and natural areas
+- water and soil
+- places for children to explore
+- nearby opportunities to grow food
+- opportunities to care for animals where appropriate
+- quiet outdoor places that do not require a purchase
+
+Land access can be private, shared, cooperative, institutional, or public.
+
+The important question is whether ordinary people can actually participate.
+
+## 3. Food became disconnected from ecology
+
+A modern food system can deliver enormous variety and convenience.
+
+It can also hide nearly every step between soil and plate.
+
+Many people rarely see food being planted, harvested, preserved, composted, or regenerated through soil.
+
+The Human Scale goal is not total local self-sufficiency. Trade is useful. Cities need regional and global systems.
+
+The goal is to restore enough local food knowledge and production that communities retain competence, resilience, and a direct relationship with nourishment.
+
+## 4. The body became abstract too
+
+The separation from land is related to a broader separation from the body.
+
+Modern life can pull attention continually into schedules, screens, symbols, money, information, arguments, and distant events.
+
+Practices such as yoga, meditation, prayer, gardening, walking, music, breathwork, manual crafts, animal care, and quiet time outdoors can bring attention back toward immediate bodily experience.
+
+The doctrine does not require one practice.
+
+The principle is simpler: **a healthy civilization should leave room for people to inhabit their bodies and experience reality directly, without constant mediation by machines or markets.**
+
+## 5. Plants and animals are not decoration
+
+A tree can provide shade, habitat, food, beauty, cooling, memory, and a meeting place.
+
+A garden can provide food, exercise, education, competence, conversation, habitat, and a reason for people to work together.
+
+Animals can teach care, responsibility, attention, interdependence, and respect for forms of life unlike ourselves.
+
+A living landscape is not merely prettier infrastructure.
+
+It can perform social, ecological, practical, and psychological functions at the same time.
+
+---
+
+# Part II — Field Guide
+
+## 6. Participate in life where you already are
+
+The answer does not have to begin with buying land.
+
+Start with whatever access exists.
+
+Grow herbs in a window. Keep a few containers. Help with a community garden. Plant a tree. Learn local plants. Compost where practical. Visit a farmers market. Volunteer on a farm. Help restore habitat. Spend regular time outside without turning the experience into another productivity task.
+
+The goal is not to perform a lifestyle.
+
+The goal is to rebuild relationship and competence.
+
+## 7. Grow some food
+
+Growing even a small amount of food changes the relationship with food.
+
+A tomato plant will not replace the grocery store. It can still teach season, soil, water, patience, failure, abundance, insects, decay, and the effort hidden inside a meal.
+
+Start small enough to succeed.
+
+A few useful plants are better than an ambitious garden that immediately becomes another burden.
+
+## 8. Learn the place you live
+
+Know something about the local watershed, climate, soil, native plants, common animals, edible plants, seasonal changes, and where food and water come from.
+
+Human Scale living is partly about becoming less anonymous to place.
+
+## 9. Practice returning to the body
+
+Choose practices that reduce abstraction and restore direct awareness.
+
+That could include:
+
+- yoga
+- meditation
+- prayer
+- walking
+- gardening
+- swimming
+- dancing
+- music
+- stretching
+- breath practice
+- cooking
+- woodworking or crafts
+- caring for animals
+- sitting quietly outdoors
+
+The practice matters less than the function: returning attention to body, place, relationship, and immediate reality.
+
+## 10. Care for something alive
+
+Growing a plant or caring for an animal creates responsibility that cannot be solved entirely through abstraction.
+
+Living things have rhythms and needs of their own.
+
+This can be grounding precisely because life does not always obey our schedule.
+
+Animal care should of course fit the welfare of the animal, the household, and the environment. The principle is care, not possession.
+
+## 11. Make shared land social
+
+A community garden is more powerful when it becomes more than a collection of fenced plots.
+
+Share seeds. Share harvests. Teach children. Hold meals. Compost together. Learn from experienced growers. Create places to sit. Plant perennials that future participants can inherit.
+
+The land becomes part of community life.
+
+---
+
+# Part III — Program
+
+## 12. A principle of meaningful land access
+
+The Human Scale Doctrine proposes a value judgment:
+
+> **Every person should have meaningful access to the living world, including nearby land where plants can grow and people can participate in caring for life.**
+
+This is not necessarily a demand that government give every individual private acreage.
+
+It is a design goal for civilization.
+
+A neighborhood should not be considered complete if residents can reach parking, retail, and roads but cannot realistically reach soil, shade, trees, gardens, play space, and living habitat.
+
+## 13. Gardens as basic neighborhood infrastructure
+
+Cities, housing developments, schools, libraries, churches, workplaces, and public agencies can make growing space normal rather than exceptional.
+
+Possible forms include:
+
+- community gardens
+- allotment gardens
+- school gardens
+- rooftop gardens
+- courtyard gardens
+- edible landscaping
+- neighborhood orchards
+- shared greenhouses
+- seed libraries
+- tool libraries
+- compost hubs
+
+These should be treated as practical infrastructure, not merely hobbies for enthusiasts.
+
+## 14. Food forests and perennial public landscapes
+
+Some public and shared landscapes can produce food while also providing habitat, shade, beauty, soil improvement, and gathering places.
+
+Food forests, orchards, edible hedges, herbs, and perennial crops will not replace conventional agriculture everywhere.
+
+They can still make productive ecology visible inside everyday neighborhoods.
+
+The important principle is to stop assuming that public landscaping must be biologically simple and mostly decorative.
+
+## 15. Children need living places
+
+Children should have opportunities to dig, climb, plant, build, observe insects, care for animals, get dirty, take age-appropriate risks, and watch living systems change over time.
+
+Schools and neighborhoods can treat these experiences as part of development rather than optional enrichment.
+
+A child who understands food only as something purchased and nature only as a special destination has been denied an important form of literacy.
+
+## 16. Public land should sometimes be productive land
+
+Parks do not all need to serve the same purpose.
+
+Some public land can remain wild. Some can support sports. Some can provide quiet. Some can host gardens, orchards, grazing, habitat restoration, community kitchens, markets, or ecological education.
+
+Human Scale policy should favor a diverse public landscape rather than one standardized model.
+
+## 17. Make access possible for renters and people without yards
+
+Land-centered policy easily becomes meaningless if it only benefits homeowners.
+
+Renters, apartment residents, children, older adults, disabled people, and low-income households should be part of the design from the beginning.
+
+That means considering distance, transportation, water access, tools, physical accessibility, security, long-term tenure for community gardens, and whether participation requires fees people cannot afford.
+
+## 18. Protect working land near communities
+
+Not every piece of land should become housing, retail, warehouses, roads, or speculative property.
+
+Regions need farms, watersheds, habitat, forests, and open land.
+
+The difficult political task is balancing housing, economic needs, property rights, ecological protection, and food production without pretending any one value eliminates the others.
+
+Human Scale policy should make those tradeoffs visible.
+
+## 19. Support regenerative experimentation
+
+Communities should be able to test forms of agriculture and land stewardship that aim to rebuild soil, conserve water, increase biodiversity, reduce harmful inputs, and produce food over long time horizons.
+
+Some methods will work better in some climates and contexts than others.
+
+The doctrine should care more about measurable outcomes than loyalty to agricultural labels.
+
+## 20. A living-world test
+
+When evaluating a neighborhood, development, institution, or public investment, ask:
+
+- Can ordinary people reach living land without making a special trip?
+- Can children safely interact with plants, soil, water, and nonhuman life?
+- Is there space to grow food?
+- Are trees and shade treated as infrastructure?
+- Does the landscape support more than decoration?
+- Can renters and people without yards participate?
+- Does the system rebuild or degrade soil, water, and habitat?
+- Can people learn where their food and water come from?
+- Does the place create opportunities for care, stewardship, and shared work?
+- Is there room for quiet and contemplation as well as recreation?
+
+No place will satisfy every goal perfectly.
+
+The test is meant to change what we notice.
+
+---
+
+## The deeper idea
+
+A society can provide entertainment, consumer goods, fast transportation, and endless information while still leaving people starved for direct contact with life.
+
+The answer is not to abandon civilization.
+
+It is to weave life back through civilization.
+
+Gardens beside apartments.
+
+Trees along streets.
+
+Food forests in neighborhoods.
+
+Animals cared for responsibly.
+
+Children who know soil.
+
+Adults who still know how to grow something.
+
+Places to practice yoga, pray, meditate, walk, breathe, work with our hands, and become quiet enough to notice the world around us.
+
+Technology can help us manage water, share knowledge, coordinate resources, monitor ecosystems, reduce drudgery, and learn from growers around the world.
+
+Then it should get out of the way.
+
+**The living world should not be something we escape to. It should be part of the place we call home.**

--- a/human-scale/land-life/index.html
+++ b/human-scale/land-life/index.html
@@ -1,0 +1,271 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Land & Life — Reconnecting Humans to the Living World</title>
+  <meta name="description" content="Chapter 2 of the Human Scale Doctrine: land access, gardens, food forests, animals, embodied practices, and living-world infrastructure." />
+  <meta name="theme-color" content="#07111f" />
+  <link rel="icon" href="../../favicon.ico" type="image/x-icon" />
+  <style>
+    :root {
+      color-scheme: dark;
+      --bg: #07111f;
+      --panel: #0c192a;
+      --text: #edf3fa;
+      --muted: #aab9ca;
+      --line: #243850;
+      --sky: #7bcaff;
+      --sun: #ffe18a;
+      --green: #a9ddb0;
+    }
+    * { box-sizing: border-box; }
+    html { scroll-behavior: smooth; }
+    body {
+      margin: 0;
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      color: var(--text);
+      line-height: 1.72;
+      background:
+        radial-gradient(circle at 15% 0%, rgba(123,202,255,.10), transparent 34rem),
+        radial-gradient(circle at 90% 8%, rgba(169,221,176,.13), transparent 32rem),
+        var(--bg);
+    }
+    a { color: var(--sky); }
+    .topbar {
+      width: min(100% - 2rem, 1060px);
+      margin: 0 auto;
+      padding: 1.25rem 0;
+      display: flex;
+      justify-content: space-between;
+      gap: 1rem;
+      color: var(--muted);
+      font-size: .94rem;
+    }
+    .topbar a { color: var(--muted); text-decoration: none; }
+    header {
+      width: min(100% - 2rem, 900px);
+      margin: 0 auto;
+      padding: 5.6rem 0 4.3rem;
+      text-align: center;
+    }
+    .eyebrow {
+      color: var(--green);
+      text-transform: uppercase;
+      letter-spacing: .16em;
+      font-size: .78rem;
+      font-weight: 850;
+    }
+    h1 {
+      margin: .8rem 0 1rem;
+      font-size: clamp(2.8rem, 8vw, 5.8rem);
+      line-height: .98;
+      letter-spacing: -.05em;
+    }
+    h2 {
+      margin: 0 0 1rem;
+      font-size: clamp(1.85rem, 5vw, 2.8rem);
+      line-height: 1.08;
+      letter-spacing: -.035em;
+    }
+    h3 { margin: 0; font-size: 1.18rem; }
+    p { margin: .9rem 0; }
+    .lead {
+      max-width: 760px;
+      margin: 0 auto;
+      color: var(--muted);
+      font-size: clamp(1.1rem, 2.5vw, 1.35rem);
+    }
+    .thesis {
+      max-width: 800px;
+      margin: 2.2rem auto 0;
+      padding: 1.35rem 1.5rem;
+      border: 1px solid rgba(169,221,176,.3);
+      border-radius: 18px;
+      background: rgba(169,221,176,.055);
+      color: #e8f8eb;
+      font-size: clamp(1.2rem, 3vw, 1.65rem);
+      font-weight: 750;
+    }
+    main { width: min(100% - 2rem, 900px); margin: 0 auto; padding-bottom: 6rem; }
+    section { padding: 3.2rem 0; border-top: 1px solid var(--line); }
+    .muted { color: var(--muted); }
+    .callout {
+      margin: 1.6rem 0 0;
+      padding: 1.3rem 1.4rem;
+      border-left: 4px solid var(--green);
+      border-radius: 0 14px 14px 0;
+      background: var(--panel);
+      font-size: 1.1rem;
+    }
+    .part {
+      color: var(--green);
+      text-transform: uppercase;
+      letter-spacing: .14em;
+      font-size: .78rem;
+      font-weight: 850;
+      margin-bottom: .55rem;
+    }
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 1rem;
+      margin-top: 1.4rem;
+    }
+    .card {
+      padding: 1.25rem;
+      border: 1px solid var(--line);
+      border-radius: 16px;
+      background: linear-gradient(145deg, rgba(17,35,58,.9), rgba(8,19,34,.9));
+    }
+    .card p { color: var(--muted); margin-bottom: 0; }
+    ul { padding-left: 1.3rem; }
+    li { margin: .55rem 0; }
+    .principle {
+      padding: 1.5rem;
+      border: 1px solid rgba(255,225,138,.26);
+      border-radius: 18px;
+      background: rgba(255,225,138,.045);
+      color: #fff4cf;
+      font-size: 1.2rem;
+      font-weight: 700;
+    }
+    .test { display: grid; gap: .7rem; margin-top: 1.2rem; }
+    .test div {
+      padding: .95rem 1rem;
+      border: 1px solid var(--line);
+      border-radius: 12px;
+      background: rgba(255,255,255,.025);
+    }
+    .closing { text-align: center; }
+    .closing strong {
+      display: block;
+      max-width: 760px;
+      margin: 2rem auto 0;
+      color: var(--sun);
+      font-size: clamp(1.55rem, 4.5vw, 2.45rem);
+      line-height: 1.15;
+      letter-spacing: -.03em;
+    }
+    footer { border-top: 1px solid var(--line); padding: 2.5rem 1rem 3.5rem; text-align: center; color: var(--muted); }
+    footer a { text-decoration: none; }
+  </style>
+</head>
+<body>
+  <nav class="topbar" aria-label="Page navigation">
+    <a href="../index.html">← Human Scale Doctrine</a>
+    <span>Chapter 2 · Land & Life</span>
+  </nav>
+
+  <header>
+    <div class="eyebrow">Diagnosis · Field Guide · Program</div>
+    <h1>Land & Life</h1>
+    <p class="lead">Reconnecting humans to the living world through land access, gardens, food forests, animals, embodied practices, and everyday participation in life.</p>
+    <div class="thesis">Humans do not only need to look at nature. We need ways to participate in the living world.</div>
+  </header>
+
+  <main>
+    <section>
+      <h2>The starting point</h2>
+      <p>Modern life often treats land as scenery, real estate, or a resource. Food arrives packaged. Water arrives through pipes. Waste disappears. Plants become decoration. Animals become pets, products, pests, or distant wildlife.</p>
+      <p>But human beings still depend on soil, water, plants, animals, fungi, insects, microbes, sunlight, weather, and seasons whether those relationships are visible or not.</p>
+      <div class="callout">Access to the living world should not be a luxury reserved for people wealthy enough to buy rural property.</div>
+    </section>
+
+    <section>
+      <div class="part">Part I — Diagnosis</div>
+      <h2>Nature became something we visit</h2>
+      <p>A person can wake indoors, travel inside a vehicle, work indoors, buy food grown far away, exercise indoors, relax through a screen, and go to sleep without touching soil or interacting with the processes that sustain life.</p>
+      <p>This frees us from many forms of dangerous and exhausting labor. It can also leave us dependent on ecological systems we barely understand.</p>
+      <div class="grid">
+        <div class="card"><h3>Land</h3><p>Often experienced primarily as property rather than a place of participation and stewardship.</p></div>
+        <div class="card"><h3>Food</h3><p>Convenient and abundant, but frequently disconnected from soil, season, labor, and local knowledge.</p></div>
+        <div class="card"><h3>Body</h3><p>Attention can live in screens, schedules, symbols, money, and distant events while direct experience becomes secondary.</p></div>
+        <div class="card"><h3>Living systems</h3><p>Trees, gardens, animals, water, and habitat are often treated as amenities instead of infrastructure for life.</p></div>
+      </div>
+    </section>
+
+    <section>
+      <h2>Ownership is not the same as access</h2>
+      <p>Private property can support freedom, stability, and stewardship. But a society where useful land is reachable only through ownership or commercial permission can leave people without wealth almost entirely separated from land.</p>
+      <p>Human Scale therefore focuses on <strong>meaningful access</strong>: gardens, community growing space, trees, edible landscapes, parks, natural areas, soil, water, places for children to explore, and opportunities to care for life.</p>
+      <div class="principle">Every person should have meaningful access to the living world, including nearby land where plants can grow and people can participate in caring for life.</div>
+    </section>
+
+    <section>
+      <h2>Returning to the body</h2>
+      <p>Yoga, meditation, prayer, gardening, walking, music, breath practice, crafts, animal care, and quiet time outdoors can all reduce abstraction and return attention to direct bodily experience.</p>
+      <p>The doctrine does not require one spiritual or physical practice.</p>
+      <div class="callout">The deeper principle is that a healthy civilization should leave room for people to inhabit their bodies and experience reality directly, without constant mediation by machines or markets.</div>
+    </section>
+
+    <section>
+      <div class="part">Part II — Field Guide</div>
+      <h2>Participate in life where you already are</h2>
+      <div class="grid">
+        <div class="card"><h3>Grow something</h3><p>Herbs, a tomato, a tree, a balcony container, or a community plot. Start small enough to succeed.</p></div>
+        <div class="card"><h3>Learn your place</h3><p>Know something about the local climate, watershed, soil, plants, animals, food, and water.</p></div>
+        <div class="card"><h3>Return to the body</h3><p>Practice yoga, meditate, pray, walk, swim, dance, cook, build, stretch, or sit quietly outside.</p></div>
+        <div class="card"><h3>Care for life</h3><p>Plants and animals create responsibility to rhythms and needs that do not always obey our schedule.</p></div>
+        <div class="card"><h3>Share land</h3><p>Use gardens for seeds, harvests, meals, teaching, compost, conversation, and recurring community.</p></div>
+        <div class="card"><h3>Build competence</h3><p>Learn enough growing, cooking, composting, repair, and ecological knowledge to be less helpless inside large systems.</p></div>
+      </div>
+    </section>
+
+    <section>
+      <div class="part">Part III — Program</div>
+      <h2>Living-world infrastructure</h2>
+      <p>Gardens and productive landscapes should be considered alongside parks, libraries, sidewalks, transit, utilities, and other infrastructure that makes a place livable.</p>
+      <div class="grid">
+        <div class="card"><h3>Community gardens</h3><p>Make growing space available to people without private yards.</p></div>
+        <div class="card"><h3>Food forests & orchards</h3><p>Use some shared landscapes for food, habitat, shade, beauty, and long-lived perennial systems.</p></div>
+        <div class="card"><h3>School gardens</h3><p>Let children dig, plant, observe insects, care for life, and understand food as a living process.</p></div>
+        <div class="card"><h3>Edible public landscapes</h3><p>Stop assuming all public planting must be decorative and biologically simple.</p></div>
+        <div class="card"><h3>Tools, seeds & compost</h3><p>Seed libraries, tool libraries, shared greenhouses, and compost hubs can lower the barrier to participation.</p></div>
+        <div class="card"><h3>Access for renters</h3><p>Design land access around apartment residents, low-income households, older adults, children, and disabled people too.</p></div>
+      </div>
+    </section>
+
+    <section>
+      <h2>Children need living places</h2>
+      <p>Children should have opportunities to dig, climb, plant, build, watch insects, care for animals, get dirty, take age-appropriate risks, and watch living systems change.</p>
+      <div class="callout">A child who understands food only as something purchased and nature only as a special destination has been denied an important form of literacy.</div>
+    </section>
+
+    <section>
+      <h2>Public land can do more</h2>
+      <p>Some public land should remain wild. Some should support sports, play, quiet, habitat, gardens, orchards, ecological restoration, community kitchens, or markets.</p>
+      <p>Regions also need working farms, watersheds, forests, habitat, housing, and economic activity. The challenge is not to pretend one value eliminates the others, but to make the tradeoffs visible and deliberate.</p>
+    </section>
+
+    <section>
+      <h2>A living-world test</h2>
+      <div class="test">
+        <div>Can ordinary people reach living land without making a special trip?</div>
+        <div>Can children safely interact with plants, soil, water, and nonhuman life?</div>
+        <div>Is there space to grow food?</div>
+        <div>Are trees and shade treated as infrastructure?</div>
+        <div>Can renters and people without yards participate?</div>
+        <div>Does the landscape rebuild or degrade soil, water, and habitat?</div>
+        <div>Can people learn where their food and water come from?</div>
+        <div>Does the place create opportunities for care, stewardship, shared work, and quiet?</div>
+      </div>
+      <p class="muted">The point is not a perfect score. The test changes what we notice when designing a place.</p>
+    </section>
+
+    <section class="closing">
+      <h2>The deeper idea</h2>
+      <p>The answer is not to abandon civilization. It is to weave life back through civilization.</p>
+      <p>Gardens beside apartments. Trees along streets. Food forests in neighborhoods. Animals cared for responsibly. Children who know soil. Adults who still know how to grow something. Places to practice yoga, pray, meditate, walk, breathe, work with our hands, and become quiet enough to notice the world around us.</p>
+      <p>Technology can help us manage water, share knowledge, coordinate resources, reduce drudgery, and understand ecosystems.</p>
+      <p>Then it should get out of the way.</p>
+      <strong>The living world should not be something we escape to. It should be part of the place we call home.</strong>
+    </section>
+  </main>
+
+  <footer>
+    <a href="../index.html">Human Scale Doctrine</a> · <a href="../../index.html">tmsteph home</a><br />
+    Living framework · August 2026
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## What changed
- Added Chapter 2 of the Human Scale Doctrine: **Land & Life — Reconnecting Humans to the Living World**.
- Added both a Markdown source and a mobile-friendly public chapter page.
- Expanded the doctrine to v0.4 with a concise principle of meaningful access to living land.
- Added land access, gardens, food forests, plants, animals, yoga/meditation and other embodied practices as part of the Human Scale direction.
- Linked Chapter 2 from the main doctrine page.

## Why
The doctrine should treat nature as more than scenery. This chapter develops the idea that ordinary people should be able to participate in the living world through soil, plants, animals, food growing, stewardship, and embodied practices—even without owning rural property.

## Scope
The chapter keeps the same simple **Diagnosis → Field Guide → Program** structure and avoids adding another reader-facing framework.