### PR TITLE
add Community chapter

### DIFF
--- a/human-scale/community/chapter.md
+++ b/human-scale/community/chapter.md
@@ -1,0 +1,323 @@
+# Chapter 3: Community — The Human Need to Belong
+
+**Human Scale Doctrine — Diagnosis / Field Guide / Program**
+
+> A good society should not merely make it possible to survive alone. It should make it easier to belong.
+
+Human beings need other human beings.
+
+We need family, friendship, cooperation, recognition, shared work, celebration, care, conflict, forgiveness, memory, and people who notice when we disappear.
+
+Modern civilization gives us extraordinary freedom to move, communicate, specialize, and choose our associations. Those freedoms matter. But a society can become highly connected while making durable belonging strangely difficult.
+
+We can know hundreds of names and still have nobody nearby who can help when the car breaks down, a child needs watching, someone gets sick, or dinner feels too lonely to eat alone.
+
+The Human Scale goal is not to recreate a compulsory village where everyone knows everyone else's business.
+
+It is to build a society where **freedom and belonging can coexist.**
+
+---
+
+# Part I — Diagnosis
+
+## 1. Community is more than contact
+
+Human contact is abundant.
+
+Durable community is something else.
+
+A community usually grows through repeated encounters over time. People recognize one another. They share places, responsibilities, stories, problems, celebrations, and small acts of trust.
+
+A comment thread is contact.
+
+A neighbor who notices your gate is open is relationship.
+
+A group chat can help coordinate community, but it cannot by itself replace people sharing a place and becoming responsible to one another.
+
+## 2. We made many relationships optional
+
+Modern life allows people to purchase services that once required more direct dependence on family, neighbors, tradespeople, congregations, clubs, and local institutions.
+
+This can be liberating. Nobody should be forced to remain dependent on an abusive family, hostile town, or oppressive institution.
+
+But when almost every need is converted into an individual transaction, people may gain convenience while losing reasons to know one another.
+
+The Human Scale question is not whether markets or professional services are bad.
+
+It is whether a healthy society also leaves room for **reciprocity**: people helping one another because they have an ongoing relationship, not because every exchange has been priced.
+
+## 3. The built environment can make strangers of neighbors
+
+Community is partly cultural, but it is also physical.
+
+If people leave private homes through garages, enter cars, drive to distant destinations, shop anonymously, and return home without spending time in shared space, repeated encounters become less likely.
+
+A neighborhood can contain thousands of people without producing much neighborhood life.
+
+By contrast, sidewalks, courtyards, stoops, gardens, playgrounds, local shops, transit stops, libraries, parks, schools, markets, and common rooms create places where ordinary life overlaps.
+
+Architecture does not create friendship automatically.
+
+It can create opportunities for friendship to happen.
+
+## 4. Time is community infrastructure
+
+People cannot build durable relationships if every useful hour is already consumed.
+
+Long or unpredictable work schedules, long commutes, caregiving overload, financial stress, and constant administrative demands can leave people with little energy for neighbors, clubs, faith communities, civic groups, shared meals, volunteering, or friendship.
+
+Community policy is therefore partly time policy.
+
+A public plaza does little good if nobody has time to use it.
+
+## 5. Children once helped connect households
+
+Children can create natural reasons for adults to know one another: play, school, caregiving, sports, birthdays, shared meals, walking, and watching out for one another.
+
+But if children have little safe freedom outside the home, every interaction must be scheduled and transported by adults.
+
+This can make childhood more isolated and parenthood more exhausting at the same time.
+
+A Human Scale community should make it easier for children to develop relationships with other children and trusted adults beyond their immediate household.
+
+## 6. Digital life is powerful but incomplete
+
+Digital communities are real communities in important ways.
+
+They can connect people who would otherwise be isolated, help minorities find one another, spread knowledge, organize projects, maintain distant relationships, and create genuine friendship.
+
+The mistake is not using digital communication.
+
+The mistake is expecting digital communication to satisfy every social function.
+
+Human Scale technology should help people coordinate, learn, find one another, and maintain relationships — then, where possible, help those relationships become embodied in shared life.
+
+## 7. Community can also become oppressive
+
+Belonging is not automatically good.
+
+Communities can gossip, exclude, shame, exploit, demand conformity, protect abusers, suppress individuality, or turn outsiders into enemies.
+
+The Human Scale Doctrine therefore does not place community above freedom.
+
+Healthy community requires boundaries, pluralism, exit, privacy, due process, and room for disagreement.
+
+The goal is **belonging without captivity.**
+
+---
+
+# Part II — Field Guide
+
+## 8. Build repeated relationships
+
+Community is usually built less by dramatic gestures than by repetition.
+
+Go to the same park. Shop at some of the same local places. Attend a recurring group. Learn neighbors' names. Join a congregation, club, garden, sports group, music scene, volunteer project, parent group, makerspace, political organization, or other community where people encounter one another repeatedly.
+
+One-off events can introduce people.
+
+Repetition turns recognition into relationship.
+
+## 9. Become useful to other people
+
+Belonging grows when people have reasons to rely on one another.
+
+Offer a ride. Cook extra food. Lend a tool. Help carry something. Watch a child when appropriate and trusted. Teach a skill. Fix something. Check on someone who is sick. Help an older neighbor with technology. Ask for help yourself when you need it.
+
+The goal is not self-sacrifice without limits.
+
+It is to become part of a web of useful relationships.
+
+## 10. Eat together
+
+Shared meals are one of the simplest forms of community infrastructure available to ordinary people.
+
+They create a reason to stop, sit, talk, share work, include children, mark time, and turn food into relationship.
+
+A Human Scale household does not need to host elaborate dinners.
+
+Soup, rice, tacos, fruit, coffee, or food from several households can be enough.
+
+The important thing is regularity and welcome.
+
+## 11. Make something together
+
+Community becomes stronger when people do more than consume entertainment beside one another.
+
+Grow a garden. Make music. Repair bicycles. Cook. Build a playground. Clean a street. Organize a festival. Restore habitat. Teach children. Start a cooperative. Run a mutual-aid project. Create art. Hold a neighborhood meeting. Build open-source tools.
+
+Shared work creates stories and competence that passive attendance cannot.
+
+## 12. Learn how to disagree without destroying the group
+
+Real community includes friction.
+
+People will disagree about money, parenting, politics, religion, noise, property, responsibility, leadership, and what happened at the last meeting.
+
+A community that cannot survive disagreement is not resilient.
+
+Useful practices include speaking directly rather than building factions, separating behavior from identity, making expectations explicit, giving people a path to repair harm, and preserving the right to leave when a relationship becomes unhealthy.
+
+## 13. Protect some local life from monetization
+
+Not every social interaction should require a purchase.
+
+Use libraries, parks, sidewalks, beaches, community rooms, gardens, churches, plazas, living rooms, porches, workshops, and other places where people can spend time together without constantly becoming customers.
+
+A society needs places where a person can belong even when they are broke.
+
+---
+
+# Part III — Program
+
+## 14. Design for repeated encounter
+
+Cities and neighborhoods should make ordinary life overlap.
+
+That can mean:
+
+- walkable access to daily needs
+- sidewalks and safe crossings
+- porches, stoops, courtyards, and common areas
+- parks and playgrounds near homes
+- neighborhood schools and libraries
+- community gardens and food forests
+- small local businesses
+- markets and gathering places
+- benches, shade, bathrooms, and drinking water
+- transit that connects people without requiring every trip to happen inside a private car
+
+The goal is not forced socialization.
+
+It is to stop designing places where isolation is the default.
+
+## 15. Treat third places as infrastructure
+
+People need places beyond home and work where they can exist with others.
+
+Libraries, parks, cafes, community centers, barbershops, faith communities, recreation centers, markets, workshops, gardens, music venues, pubs, plazas, beaches, and similar places can all serve this function.
+
+Some are public. Some are private. Some are religious, cooperative, nonprofit, or commercial.
+
+A resilient community needs a mixture.
+
+## 16. Make caregiving less isolated
+
+Children, disability, illness, and aging create needs that are difficult for one household to carry alone.
+
+Communities can experiment with:
+
+- parent cooperatives
+- shared childcare
+- multigenerational housing
+- respite networks
+- meal trains
+- elder support
+- neighborhood emergency plans
+- accessible public spaces
+- community health and caregiving organizations
+
+Professional care remains essential in many situations.
+
+The goal is to add social support around professional systems, not replace expertise with good intentions.
+
+## 17. Give people time to participate
+
+If society values community, civic participation cannot depend entirely on exhausted people donating whatever energy remains after work and commuting.
+
+Workplaces and governments should consider how scheduling, paid leave, working hours, transportation, and administrative burden affect family and community life.
+
+A society that consumes all of people's time and then complains that nobody volunteers has misunderstood the problem.
+
+## 18. Keep local institutions understandable
+
+People are more likely to participate when they can understand who makes decisions, where meetings happen, how money is spent, and how to influence an outcome.
+
+Neighborhood councils, school boards, cooperatives, homeowner and tenant groups, congregations, clubs, local businesses, and city institutions should aim for understandable processes and visible accountability.
+
+Local does not automatically mean democratic or fair.
+
+But when decisions can be made close to the people affected without sacrificing rights, competence, or necessary scale, proximity can make participation easier.
+
+## 19. Support mutual aid without romanticizing it
+
+Neighbors helping neighbors can build resilience and dignity.
+
+But mutual aid should not become an excuse for society to abandon people with needs too large for informal networks.
+
+A casserole cannot replace a hospital.
+
+A neighborhood fundraiser cannot replace every social insurance system.
+
+Human Scale society should combine strong informal relationships with capable larger institutions where scale is genuinely necessary.
+
+## 20. Create rituals and celebrations
+
+Communities need more than problem-solving.
+
+They need reasons to celebrate being together.
+
+Festivals, meals, music, sports, religious observances, seasonal events, birthdays, markets, dances, volunteer days, neighborhood traditions, and public art help create shared memory.
+
+A place becomes home partly through repetition and story.
+
+## 21. Make room for plural communities
+
+A person should not need one community to satisfy every part of life.
+
+Someone may belong simultaneously to a family, neighborhood, church, yoga class, union, gaming community, band, garden, political organization, professional network, and group of old friends.
+
+This overlap can protect freedom.
+
+If one group becomes unhealthy, the person still has relationships and identity elsewhere.
+
+A Human Scale society should therefore favor an ecosystem of associations rather than one institution controlling belonging.
+
+## 22. A community test
+
+When evaluating a neighborhood, workplace, school, technology, housing project, or policy, ask:
+
+- Does it make repeated human contact easier or harder?
+- Are there places to gather without spending money?
+- Do people have enough time to participate in relationships and civic life?
+- Can children form safe, increasingly independent relationships beyond their household?
+- Can older and disabled people remain part of ordinary community life?
+- Are there opportunities to contribute, not just receive services?
+- Can people disagree or leave without losing every social connection?
+- Does technology help people coordinate real relationships or mainly capture attention?
+- Are local decisions understandable and influenceable?
+- Does the system combine mutual help with capable institutions where larger scale is necessary?
+
+No community will satisfy every need.
+
+The point is to design places where belonging has somewhere to grow.
+
+---
+
+## The deeper idea
+
+The Human Scale future is not just greener or more technologically humane.
+
+It is more relational.
+
+A garden matters partly because plants grow there — and partly because people meet there.
+
+A sidewalk matters partly because it moves a body — and partly because neighbors see one another.
+
+A local shop matters partly because it sells something — and partly because somebody knows your name.
+
+A festival matters even when it produces nothing measurable.
+
+A child needs more than safe housing. An older person needs more than medical care. An adult needs more than employment and entertainment.
+
+We need to be known.
+
+We need to be useful.
+
+We need people to celebrate with and people who will show up when life falls apart.
+
+Technology can help us find one another, coordinate, communicate, translate, organize, learn, and share resources.
+
+Then it should help us return to one another.
+
+**A humane civilization should make it easier for strangers to become neighbors, and for neighbors to become people who matter to one another.**

--- a/human-scale/community/index.html
+++ b/human-scale/community/index.html
@@ -1,0 +1,262 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Community — The Human Need to Belong</title>
+  <meta name="description" content="Chapter 3 of the Human Scale Doctrine: belonging, neighbors, shared places, mutual aid, third places, time, and community infrastructure." />
+  <meta name="theme-color" content="#07111f" />
+  <link rel="icon" href="../../favicon.ico" type="image/x-icon" />
+  <style>
+    :root {
+      color-scheme: dark;
+      --bg: #07111f;
+      --panel: #0c192a;
+      --text: #edf3fa;
+      --muted: #aab9ca;
+      --line: #243850;
+      --sky: #7bcaff;
+      --sun: #ffe18a;
+      --green: #a9ddb0;
+    }
+    * { box-sizing: border-box; }
+    html { scroll-behavior: smooth; }
+    body {
+      margin: 0;
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      color: var(--text);
+      line-height: 1.72;
+      background:
+        radial-gradient(circle at 12% 0%, rgba(123,202,255,.12), transparent 34rem),
+        radial-gradient(circle at 92% 8%, rgba(169,221,176,.10), transparent 32rem),
+        var(--bg);
+    }
+    a { color: var(--sky); }
+    .topbar {
+      width: min(100% - 2rem, 1060px);
+      margin: 0 auto;
+      padding: 1.25rem 0;
+      display: flex;
+      justify-content: space-between;
+      gap: 1rem;
+      color: var(--muted);
+      font-size: .94rem;
+    }
+    .topbar a { color: var(--muted); text-decoration: none; }
+    header {
+      width: min(100% - 2rem, 900px);
+      margin: 0 auto;
+      padding: 5.6rem 0 4.3rem;
+      text-align: center;
+    }
+    .eyebrow {
+      color: var(--sky);
+      text-transform: uppercase;
+      letter-spacing: .16em;
+      font-size: .78rem;
+      font-weight: 850;
+    }
+    h1 {
+      margin: .8rem 0 1rem;
+      font-size: clamp(2.8rem, 8vw, 5.8rem);
+      line-height: .98;
+      letter-spacing: -.05em;
+    }
+    h2 {
+      margin: 0 0 1rem;
+      font-size: clamp(1.85rem, 5vw, 2.8rem);
+      line-height: 1.08;
+      letter-spacing: -.035em;
+    }
+    h3 { margin: 0; font-size: 1.18rem; }
+    p { margin: .9rem 0; }
+    .lead {
+      max-width: 760px;
+      margin: 0 auto;
+      color: var(--muted);
+      font-size: clamp(1.1rem, 2.5vw, 1.35rem);
+    }
+    .thesis {
+      max-width: 800px;
+      margin: 2.2rem auto 0;
+      padding: 1.35rem 1.5rem;
+      border: 1px solid rgba(123,202,255,.3);
+      border-radius: 18px;
+      background: rgba(123,202,255,.055);
+      color: #eaf7ff;
+      font-size: clamp(1.2rem, 3vw, 1.65rem);
+      font-weight: 750;
+    }
+    main { width: min(100% - 2rem, 900px); margin: 0 auto; padding-bottom: 6rem; }
+    section { padding: 3.2rem 0; border-top: 1px solid var(--line); }
+    .muted { color: var(--muted); }
+    .callout {
+      margin: 1.6rem 0 0;
+      padding: 1.3rem 1.4rem;
+      border-left: 4px solid var(--sky);
+      border-radius: 0 14px 14px 0;
+      background: var(--panel);
+      font-size: 1.1rem;
+    }
+    .part {
+      color: var(--green);
+      text-transform: uppercase;
+      letter-spacing: .14em;
+      font-size: .78rem;
+      font-weight: 850;
+      margin-bottom: .55rem;
+    }
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 1rem;
+      margin-top: 1.4rem;
+    }
+    .card {
+      padding: 1.25rem;
+      border: 1px solid var(--line);
+      border-radius: 16px;
+      background: linear-gradient(145deg, rgba(17,35,58,.9), rgba(8,19,34,.9));
+    }
+    .card p { color: var(--muted); margin-bottom: 0; }
+    ul { padding-left: 1.3rem; }
+    li { margin: .55rem 0; }
+    .principle {
+      padding: 1.5rem;
+      border: 1px solid rgba(255,225,138,.26);
+      border-radius: 18px;
+      background: rgba(255,225,138,.045);
+      color: #fff4cf;
+      font-size: 1.2rem;
+      font-weight: 700;
+    }
+    .test { display: grid; gap: .7rem; margin-top: 1.2rem; }
+    .test div {
+      padding: .95rem 1rem;
+      border: 1px solid var(--line);
+      border-radius: 12px;
+      background: rgba(255,255,255,.025);
+    }
+    .closing { text-align: center; }
+    .closing strong {
+      display: block;
+      max-width: 760px;
+      margin: 2rem auto 0;
+      color: var(--sun);
+      font-size: clamp(1.55rem, 4.5vw, 2.45rem);
+      line-height: 1.15;
+      letter-spacing: -.03em;
+    }
+    footer { border-top: 1px solid var(--line); padding: 2.5rem 1rem 3.5rem; text-align: center; color: var(--muted); }
+    footer a { text-decoration: none; }
+  </style>
+</head>
+<body>
+  <nav class="topbar" aria-label="Page navigation">
+    <a href="../index.html">← Human Scale Doctrine</a>
+    <span>Chapter 3 · Community</span>
+  </nav>
+
+  <header>
+    <div class="eyebrow">Diagnosis · Field Guide · Program</div>
+    <h1>Community</h1>
+    <p class="lead">The human need to belong — and how places, time, institutions, and technology can help strangers become neighbors.</p>
+    <div class="thesis">A good society should not merely make it possible to survive alone. It should make it easier to belong.</div>
+  </header>
+
+  <main>
+    <section>
+      <h2>The starting point</h2>
+      <p>Human beings need family, friendship, cooperation, recognition, shared work, celebration, care, conflict, forgiveness, memory, and people who notice when we disappear.</p>
+      <p>Modern life gives us extraordinary freedom to move, communicate, specialize, and choose our associations. Those freedoms matter. But connection is not the same as durable belonging.</p>
+      <div class="callout">The Human Scale goal is not a compulsory village. It is a society where <strong>freedom and belonging can coexist.</strong></div>
+    </section>
+
+    <section>
+      <div class="part">Part I — Diagnosis</div>
+      <h2>Community is more than contact</h2>
+      <p>Community grows through repeated encounters, shared places, responsibilities, stories, problems, celebrations, and small acts of trust.</p>
+      <div class="grid">
+        <div class="card"><h3>Transactions</h3><p>Convenience can replace relationships when every need becomes an individual purchase.</p></div>
+        <div class="card"><h3>Place</h3><p>Neighborhoods can hold thousands of residents while giving them few reasons to encounter one another.</p></div>
+        <div class="card"><h3>Time</h3><p>Long work, commuting, caregiving, and administrative burdens can consume the hours community requires.</p></div>
+        <div class="card"><h3>Digital life</h3><p>Online communities can be real and valuable, but they cannot satisfy every function of embodied social life.</p></div>
+      </div>
+    </section>
+
+    <section>
+      <h2>Belonging without captivity</h2>
+      <p>Community can also gossip, exclude, shame, demand conformity, protect abuse, or turn outsiders into enemies.</p>
+      <div class="principle">Healthy community needs belonging and obligation, but also privacy, pluralism, boundaries, disagreement, and the ability to leave.</div>
+    </section>
+
+    <section>
+      <div class="part">Part II — Field Guide</div>
+      <h2>Build repeated relationships</h2>
+      <div class="grid">
+        <div class="card"><h3>Show up repeatedly</h3><p>Use the same parks, shops, gardens, groups, congregations, classes, clubs, or public places often enough to become recognizable.</p></div>
+        <div class="card"><h3>Become useful</h3><p>Offer rides, food, tools, skills, help, attention, and care — and allow other people to help you too.</p></div>
+        <div class="card"><h3>Eat together</h3><p>Shared meals turn food into time, conversation, ritual, care, and relationship.</p></div>
+        <div class="card"><h3>Make things together</h3><p>Gardens, music, repair, cooking, festivals, mutual aid, art, open source, and civic projects create shared stories.</p></div>
+        <div class="card"><h3>Practice disagreement</h3><p>Real community includes friction. Learn to address conflict without immediately destroying the relationship or the group.</p></div>
+        <div class="card"><h3>Keep some life noncommercial</h3><p>Use places where people can belong without constantly needing to buy something.</p></div>
+      </div>
+    </section>
+
+    <section>
+      <div class="part">Part III — Program</div>
+      <h2>Community infrastructure</h2>
+      <p>Community is not created by infrastructure alone, but infrastructure can make repeated human contact much easier.</p>
+      <div class="grid">
+        <div class="card"><h3>Shared places</h3><p>Libraries, parks, markets, gardens, playgrounds, community centers, courtyards, sidewalks, and local businesses.</p></div>
+        <div class="card"><h3>Third places</h3><p>Support places beyond home and work where people can linger, meet, create, worship, talk, or simply be around others.</p></div>
+        <div class="card"><h3>Care networks</h3><p>Parent cooperatives, meal trains, elder support, respite, multigenerational housing, and neighborhood emergency plans.</p></div>
+        <div class="card"><h3>Time for life</h3><p>Work schedules, leave, commuting, and bureaucracy should be judged partly by what they leave available for family and community.</p></div>
+        <div class="card"><h3>Local participation</h3><p>Make nearby institutions understandable enough that ordinary people can know who decides, how money is used, and how to participate.</p></div>
+        <div class="card"><h3>Celebration</h3><p>Festivals, meals, music, sports, worship, markets, traditions, and public art help turn a location into a place with memory.</p></div>
+      </div>
+    </section>
+
+    <section>
+      <h2>Mutual aid and capable institutions</h2>
+      <p>Neighbors helping neighbors builds resilience. It should not become an excuse to abandon people whose needs require hospitals, professional care, large infrastructure, social insurance, or other capable institutions.</p>
+      <div class="callout">A casserole cannot replace a hospital. Human Scale means using human relationships where they work and larger systems where scale is genuinely necessary.</div>
+    </section>
+
+    <section>
+      <h2>Children and community</h2>
+      <p>Children should be able to develop relationships with other children and trusted adults beyond their immediate household. Safe streets, nearby play, schools, gardens, parks, and gradually increasing independence can make childhood more social while reducing the burden on parents to schedule and transport every interaction.</p>
+    </section>
+
+    <section>
+      <h2>A community test</h2>
+      <div class="test">
+        <div>Does this place make repeated human contact easier or harder?</div>
+        <div>Can people gather without spending money?</div>
+        <div>Do people have enough time to participate?</div>
+        <div>Can children and older people remain part of ordinary community life?</div>
+        <div>Are there opportunities to contribute, not just receive services?</div>
+        <div>Can people disagree or leave without losing every social connection?</div>
+        <div>Does technology help coordinate real relationships or mainly capture attention?</div>
+        <div>Are nearby decisions understandable and influenceable?</div>
+      </div>
+      <p class="muted">The goal is not forced togetherness. It is to give belonging somewhere to grow.</p>
+    </section>
+
+    <section class="closing">
+      <h2>The deeper idea</h2>
+      <p>A garden matters partly because plants grow there — and partly because people meet there.</p>
+      <p>A sidewalk matters partly because it moves a body — and partly because neighbors see one another.</p>
+      <p>A local shop matters partly because it sells something — and partly because somebody knows your name.</p>
+      <p>Technology can help us find one another, coordinate, communicate, organize, learn, and share resources.</p>
+      <p>Then it should help us return to one another.</p>
+      <strong>A humane civilization should make it easier for strangers to become neighbors, and for neighbors to become people who matter to one another.</strong>
+    </section>
+  </main>
+
+  <footer>
+    <a href="../index.html">Human Scale Doctrine</a> · <a href="../../index.html">tmsteph home</a><br />
+    Living framework · August 2026
+  </footer>
+</body>
+</html>

--- a/human-scale/doctrine.md
+++ b/human-scale/doctrine.md
@@ -1,6 +1,6 @@
 # The Human Scale Doctrine
 
-**Version 0.4 — August 2026**
+**Version 0.5 — August 2026**
 
 > Humanity became powerful faster than it became wise.
 
@@ -90,6 +90,7 @@ A civilization is progressing when more people can:
 - live healthy lives
 - spend time with people they love
 - raise children in safe communities
+- belong to durable relationships and communities where people can rely on one another
 - understand and influence the systems around them
 - create rather than merely consume
 - work without surrendering their entire waking lives
@@ -131,13 +132,15 @@ It should favor:
 - neighborhoods where people repeatedly encounter one another
 - voluntary associations
 - mutual aid
+- time for relationships and civic life
 - local ownership
 - cooperative creation
-- meaningful public spaces
+- meaningful public spaces and third places
 - meaningful access to living land
 - decentralized political and economic power
 - cultural pluralism
 - freedom of belief
+- privacy, boundaries, and the ability to leave unhealthy groups
 - room for spiritual life
 
 Large systems will still exist. The principle is that scale should have to justify itself.
@@ -162,11 +165,15 @@ The first long-form chapter explores the mismatch between recurring human needs 
 
 The second chapter argues that meaningful access to soil, plants, animals, gardens, food forests, open sky, and embodied practices should be part of ordinary life rather than a luxury. It explores both personal participation and public design.
 
+### 3. [Community — The Human Need to Belong](community/index.html)
+
+The third chapter explores repeated relationships, neighbors, shared meals and work, third places, caregiving, local participation, digital community, and the challenge of creating belonging without sacrificing freedom or pluralism.
+
 Long chapters are optional depth. The doctrine itself should remain readable without them.
 
 ## Where This Can Grow
 
-Future subjects may include technology, energy, economics, community, education, artificial intelligence, spirituality, governance, food, architecture, transportation, work, family, health, ecology, and open source.
+Future subjects may include technology, energy, economics, education, artificial intelligence, spirituality, governance, food, architecture, transportation, work, family, health, ecology, and open source.
 
 We do not need a complete system before we can learn, write, test ideas, or act.
 
@@ -187,6 +194,7 @@ Among the questions still to explore:
 - What is the ideal scale for different institutions?
 - How much localization is resilient without becoming isolationist?
 - How can land access be expanded without pretending ownership, housing, farming, ecology, and public access have no tradeoffs?
+- How can institutions make belonging easier without making community compulsory or oppressive?
 - How should ownership change in a highly automated economy?
 - What work should humans continue doing even when machines can do it?
 - How can dense cities become deeply connected to nature?

--- a/human-scale/index.html
+++ b/human-scale/index.html
@@ -197,7 +197,7 @@
 <body>
   <nav class="topbar" aria-label="Page navigation">
     <a href="../index.html">← tmsteph home</a>
-    <span>Living doctrine · v0.4</span>
+    <span>Living doctrine · v0.5</span>
   </nav>
 
   <header>
@@ -260,13 +260,13 @@
 
     <section>
       <h2>What progress should mean</h2>
-      <p>Progress is more than GDP, speed, scale, convenience, or computational power. A civilization is progressing when people have healthier bodies, deeper relationships, meaningful work, time, agency, access to nature and living land, material security, room to create, and a living world to pass on.</p>
+      <p>Progress is more than GDP, speed, scale, convenience, or computational power. A civilization is progressing when people have healthier bodies, deeper relationships, durable community, meaningful work, time, agency, access to nature and living land, material security, room to create, and a living world to pass on.</p>
     </section>
 
     <section>
       <h2>The direction</h2>
       <p><strong>Technology:</strong> open, repairable, distributed, resilient, and quiet enough to disappear when it is not needed.</p>
-      <p><strong>Society:</strong> stronger families and communities, meaningful public space, access to living land, local ownership where it works, pluralism, and power that stays understandable and accountable.</p>
+      <p><strong>Society:</strong> stronger families and communities, repeated local relationships, meaningful public space, access to living land, time for civic life, pluralism, and power that stays understandable and accountable.</p>
       <p><strong>Inner life:</strong> room for science and reason alongside prayer, meditation, yoga, art, music, philosophy, nature, and the human search for meaning.</p>
       <div class="callout">The goal is not maximum technology. The goal is the right technology in the right place, serving life.</div>
     </section>
@@ -276,6 +276,7 @@
       <p>The doctrine should remain readable on its own. Longer chapters are optional depth, not prerequisites.</p>
       <a class="chapter" href="human-nature/index.html"><strong>Chapter 1: Human Nature — The Environment We Were Built For →</strong><span>How recurring human needs collide with modern environments, what we can do personally, and what we may want to change together.</span></a>
       <a class="chapter" href="land-life/index.html"><strong>Chapter 2: Land & Life — Reconnecting Humans to the Living World →</strong><span>Land access, gardens, food forests, plants, animals, embodied practice, and the idea that living systems belong inside everyday infrastructure.</span></a>
+      <a class="chapter" href="community/index.html"><strong>Chapter 3: Community — The Human Need to Belong →</strong><span>Neighbors, repeated relationships, shared meals and work, third places, caregiving, local participation, and belonging without captivity.</span></a>
     </section>
 
     <section>
@@ -289,7 +290,7 @@
       <p>We can keep the knowledge. We can keep the science. We can keep the computers.</p>
       <p>And we can use them to build a civilization in which people once again belong to their bodies, their communities, and the Earth.</p>
       <strong>The village and the computer can coexist.</strong>
-      <p class="version">Version 0.4 · A living doctrine, expected to change as its ideas are challenged, tested, and refined.</p>
+      <p class="version">Version 0.5 · A living doctrine, expected to change as its ideas are challenged, tested, and refined.</p>
     </section>
   </main>
 


### PR DESCRIPTION
## What changed
- Added Chapter 3 of the Human Scale Doctrine: **Community — The Human Need to Belong**.
- Added Markdown source and a mobile-friendly public chapter page.
- Updated the doctrine to v0.5 and linked Chapter 3 from the main Human Scale page.
- Developed community as repeated relationships, shared places, mutual help, caregiving, third places, civic time, and local participation.
- Explicitly protects pluralism, privacy, boundaries, disagreement, and the ability to leave unhealthy groups.

## Why
The first two chapters establish human needs and living-world participation. Chapter 3 asks how humans live together without romanticizing compulsory or oppressive community.

## Scope
The chapter keeps the simple **Diagnosis → Field Guide → Program** structure and adds no new overarching framework.