### PR TITLE
add Work & Time chapter

### DIFF
--- a/human-scale/doctrine.md
+++ b/human-scale/doctrine.md
@@ -1,6 +1,6 @@
 # The Human Scale Doctrine
 
-**Version 0.5 — August 2026**
+**Version 0.6 — August 2026**
 
 > Humanity became powerful faster than it became wise.
 
@@ -94,6 +94,7 @@ A civilization is progressing when more people can:
 - understand and influence the systems around them
 - create rather than merely consume
 - work without surrendering their entire waking lives
+- retain meaningful time that is not claimed by employment or constant economic activity
 - access nature and public space
 - participate directly in the living world through soil, plants, food, animals, and stewardship
 - obtain food, shelter, education, and healthcare without permanent desperation
@@ -132,7 +133,7 @@ It should favor:
 - neighborhoods where people repeatedly encounter one another
 - voluntary associations
 - mutual aid
-- time for relationships and civic life
+- time for relationships, care, rest, and civic life
 - local ownership
 - cooperative creation
 - meaningful public spaces and third places
@@ -169,11 +170,15 @@ The second chapter argues that meaningful access to soil, plants, animals, garde
 
 The third chapter explores repeated relationships, neighbors, shared meals and work, third places, caregiving, local participation, digital community, and the challenge of creating belonging without sacrificing freedom or pluralism.
 
+### 4. [Work & Time — What Is a Human Life For?](work-time/index.html)
+
+The fourth chapter asks how much of life employment should consume, distinguishes paid work from human contribution, and explores predictable time, worker agency, care, commuting, automation, shorter-work experiments, and the idea that productivity should sometimes give time back.
+
 Long chapters are optional depth. The doctrine itself should remain readable without them.
 
 ## Where This Can Grow
 
-Future subjects may include technology, energy, economics, education, artificial intelligence, spirituality, governance, food, architecture, transportation, work, family, health, ecology, and open source.
+Future subjects may include technology, energy, economics, education, artificial intelligence, spirituality, governance, food, architecture, transportation, family, health, ecology, and open source.
 
 We do not need a complete system before we can learn, write, test ideas, or act.
 
@@ -197,6 +202,7 @@ Among the questions still to explore:
 - How can institutions make belonging easier without making community compulsory or oppressive?
 - How should ownership change in a highly automated economy?
 - What work should humans continue doing even when machines can do it?
+- How should gains from productivity be divided among wages, prices, profits, public benefits, and human time?
 - How can dense cities become deeply connected to nature?
 - How do we preserve scientific rigor while allowing spiritual pluralism?
 - What should children learn in a civilization built around human flourishing?

--- a/human-scale/index.html
+++ b/human-scale/index.html
@@ -197,7 +197,7 @@
 <body>
   <nav class="topbar" aria-label="Page navigation">
     <a href="../index.html">← tmsteph home</a>
-    <span>Living doctrine · v0.5</span>
+    <span>Living doctrine · v0.6</span>
   </nav>
 
   <header>
@@ -260,13 +260,13 @@
 
     <section>
       <h2>What progress should mean</h2>
-      <p>Progress is more than GDP, speed, scale, convenience, or computational power. A civilization is progressing when people have healthier bodies, deeper relationships, durable community, meaningful work, time, agency, access to nature and living land, material security, room to create, and a living world to pass on.</p>
+      <p>Progress is more than GDP, speed, scale, convenience, or computational power. A civilization is progressing when people have healthier bodies, deeper relationships, durable community, meaningful work, time that is actually theirs, agency, access to nature and living land, material security, room to create, and a living world to pass on.</p>
     </section>
 
     <section>
       <h2>The direction</h2>
       <p><strong>Technology:</strong> open, repairable, distributed, resilient, and quiet enough to disappear when it is not needed.</p>
-      <p><strong>Society:</strong> stronger families and communities, repeated local relationships, meaningful public space, access to living land, time for civic life, pluralism, and power that stays understandable and accountable.</p>
+      <p><strong>Society:</strong> stronger families and communities, repeated local relationships, meaningful public space, access to living land, time for care, rest and civic life, pluralism, and power that stays understandable and accountable.</p>
       <p><strong>Inner life:</strong> room for science and reason alongside prayer, meditation, yoga, art, music, philosophy, nature, and the human search for meaning.</p>
       <div class="callout">The goal is not maximum technology. The goal is the right technology in the right place, serving life.</div>
     </section>
@@ -277,6 +277,7 @@
       <a class="chapter" href="human-nature/index.html"><strong>Chapter 1: Human Nature — The Environment We Were Built For →</strong><span>How recurring human needs collide with modern environments, what we can do personally, and what we may want to change together.</span></a>
       <a class="chapter" href="land-life/index.html"><strong>Chapter 2: Land & Life — Reconnecting Humans to the Living World →</strong><span>Land access, gardens, food forests, plants, animals, embodied practice, and the idea that living systems belong inside everyday infrastructure.</span></a>
       <a class="chapter" href="community/index.html"><strong>Chapter 3: Community — The Human Need to Belong →</strong><span>Neighbors, repeated relationships, shared meals and work, third places, caregiving, local participation, and belonging without captivity.</span></a>
+      <a class="chapter" href="work-time/index.html"><strong>Chapter 4: Work & Time — What Is a Human Life For? →</strong><span>Paid work and human contribution, predictable time, commuting, care, worker agency, automation, and the possibility that productivity should give some of our lives back.</span></a>
     </section>
 
     <section>
@@ -290,7 +291,7 @@
       <p>We can keep the knowledge. We can keep the science. We can keep the computers.</p>
       <p>And we can use them to build a civilization in which people once again belong to their bodies, their communities, and the Earth.</p>
       <strong>The village and the computer can coexist.</strong>
-      <p class="version">Version 0.5 · A living doctrine, expected to change as its ideas are challenged, tested, and refined.</p>
+      <p class="version">Version 0.6 · A living doctrine, expected to change as its ideas are challenged, tested, and refined.</p>
     </section>
   </main>
 

--- a/human-scale/work-time/chapter.md
+++ b/human-scale/work-time/chapter.md
@@ -1,0 +1,405 @@
+# Chapter 4: Work & Time — What Is a Human Life For?
+
+**Human Scale Doctrine — Diagnosis / Field Guide / Program**
+
+> Work should support a human life. A human life should not exist mainly to support work.
+
+Work matters.
+
+People need to contribute, build competence, solve problems, provide for others, create, repair, teach, care, grow food, make music, organize, discover, and take responsibility.
+
+But paid employment is only one form of useful work.
+
+Raising a child is work. Caring for an older person is work. Cooking, cleaning, gardening, repairing a home, volunteering, making art, maintaining a neighborhood, learning a craft, participating in civic life, and helping a friend can all create real value even when no wage is attached.
+
+Modern economies are very good at measuring paid production.
+
+They are much worse at answering a more basic question:
+
+**How much of a human life should be consumed by earning the right to keep living it?**
+
+The Human Scale goal is not a society without effort, ambition, responsibility, or difficult work.
+
+It is a society where work serves life rather than swallowing it.
+
+---
+
+# Part I — Diagnosis
+
+## 1. Employment became the center of adult life
+
+For many adults, work determines:
+
+- when they wake up
+- where they live
+- when they eat
+- when they can see family
+- whether they can travel
+- how much daylight they experience
+- how tired they are
+- whether they can participate in community
+- how much time remains for exercise, prayer, art, friendship, gardening, parenting, or rest
+
+This is an enormous amount of power for one institution to hold over a life.
+
+Work can be meaningful and still occupy too much territory.
+
+## 2. Paid work and useful work are not the same thing
+
+Markets are useful for coordinating enormous amounts of activity.
+
+But price does not perfectly measure human importance.
+
+A person can be highly paid for work that matters little to their community and unpaid for work that holds a household together.
+
+Human Scale economics should therefore resist treating wage income as the only proof that somebody is contributing.
+
+Caregiving, domestic work, mentorship, ecological stewardship, creative work, mutual aid, and civic participation are part of the productive life of a society too.
+
+## 3. Time is the hidden cost
+
+Income matters because people need material security.
+
+But time is also a finite resource.
+
+A job that pays for eight hours can consume much more than eight hours once commuting, preparation, recovery, irregular scheduling, messages, travel, and mental spillover are included.
+
+The same is true of bureaucracy around work: forms, scheduling systems, benefits administration, credentialing, meetings, and constant digital communication.
+
+Human Scale thinking treats time as a real cost rather than an invisible one.
+
+## 4. Predictability matters almost as much as quantity
+
+A person may technically have free hours and still be unable to use them well if work schedules change constantly.
+
+Unpredictable shifts can make childcare, classes, medical appointments, shared meals, volunteering, worship, exercise, sleep, and relationships difficult to maintain.
+
+A life cannot be planned around time that may disappear without warning.
+
+## 5. Work can provide meaning — and exploit the need for meaning
+
+Humans often want to be useful.
+
+We want competence, recognition, responsibility, challenge, mastery, and a sense that our effort matters.
+
+Good work can provide all of these.
+
+But employers and institutions can also use the language of mission, passion, family, hustle, or loyalty to normalize excessive demands.
+
+Meaningful work should not require surrendering every boundary.
+
+## 6. Commuting changes the geography of life
+
+A long commute does more than consume fuel or money.
+
+It separates home from work, reduces time near family and neighbors, increases sedentary time, and can make everyday errands and caregiving more complicated.
+
+Remote work solves some of this for some jobs, but it can also blur the line between work and home and increase isolation.
+
+The goal is not one universal work location.
+
+It is to reduce unnecessary distance and unnecessary time loss.
+
+## 7. Productivity gains do not automatically become free time
+
+Technology can let people produce more with less labor.
+
+But greater productivity does not automatically create shorter working lives.
+
+The gains can become lower prices, higher profits, higher wages, more output, more consumption, or some combination.
+
+Human Scale politics should make the distribution of productivity gains an explicit question.
+
+If machines can do more of the work, one possible benefit should be that humans recover some time.
+
+## 8. Automation creates both liberation and insecurity
+
+Automation can remove dangerous, repetitive, exhausting, and bureaucratic work.
+
+That is good when the benefits are shared.
+
+But automation can also remove bargaining power, income, identity, or stability before people have a realistic alternative.
+
+The Human Scale position is neither "automate everything" nor "protect every existing job forever."
+
+The question is:
+
+**Which work should machines take, which work should humans keep, and who receives the time and wealth created by automation?**
+
+---
+
+# Part II — Field Guide
+
+## 9. Audit the real workday
+
+For one week, notice the full footprint of work.
+
+Count:
+
+- paid hours
+- commuting
+- preparation
+- unpaid messages and calls
+- recovery time
+- schedule anxiety
+- work-related errands
+- time lost because shifts are unpredictable
+
+The goal is not to complain about every minute.
+
+It is to see the real trade.
+
+## 10. Protect some time that is not for sale
+
+A healthy life needs periods that are not continuously available to employers, customers, notifications, or side hustles.
+
+Protect some time for family, sleep, food, movement, community, spiritual practice, creative work, gardening, friendship, or simply doing nothing productive.
+
+Rest is not a failure to monetize yourself.
+
+## 11. Seek agency, not only status
+
+A prestigious job with little control over time, place, methods, or boundaries may fit a person worse than a less impressive job with more autonomy.
+
+When evaluating work, ask about:
+
+- schedule control
+- predictability
+- commute
+- physical and mental strain
+- learning
+- usefulness
+- relationships
+- flexibility
+- room for family and community
+- ability to leave
+
+Income is important.
+
+It is not the only dimension of a good job.
+
+## 12. Keep useful skills outside your job title
+
+Do not let employment become the only source of competence or identity.
+
+Cook. Grow something. Repair something. Make music. Learn first aid. Volunteer. Build. Teach. Care for people. Join a project. Learn how your city works.
+
+A person is more resilient when usefulness extends beyond the labor market.
+
+## 13. Treat commuting as a design problem
+
+If possible, consider the commute when choosing housing, work, school, childcare, or transportation.
+
+Walk, bike, transit, carpool, work remotely, or cluster trips where those options genuinely improve life.
+
+The point is not purity.
+
+It is to stop pretending travel time is free.
+
+## 14. Build boundaries around digital work
+
+When a job allows it, separate urgent communication from everything that merely feels urgent.
+
+Turn off unnecessary alerts. Use defined response windows. Keep work accounts off personal devices when practical. Make expectations explicit.
+
+Technology should reduce coordination cost, not turn every waking hour into potential work time.
+
+## 15. Coordinate time with people you love
+
+Free time is more valuable when it overlaps.
+
+A household where everybody has different, unstable schedules may have many theoretical free hours and very little shared life.
+
+Protect recurring meals, mornings, evenings, weekends, worship, walks, childcare handoffs, or other predictable points of connection where possible.
+
+Human time is social time.
+
+---
+
+# Part III — Program
+
+## 16. Judge jobs by more than wages
+
+A Human Scale labor system should care about compensation and also:
+
+- safety
+- predictable schedules
+- reasonable working hours
+- worker voice
+- autonomy
+- time off
+- family compatibility
+- commute burden
+- physical and psychological strain
+- opportunity to learn
+- dignity
+- whether technology gives time back or merely raises expectations
+
+A high wage does not automatically make a destructive job humane.
+
+A pleasant workplace does not justify inadequate pay.
+
+Both matter.
+
+## 17. Make predictable scheduling a serious labor issue
+
+Workers should have enough notice and stability to organize the rest of life wherever the nature of the job allows it.
+
+Some industries genuinely face emergencies, weather, events, seasonal demand, or unpredictable workloads.
+
+That does not erase the value of predictability.
+
+Employers should have to justify instability rather than treating workers' time as infinitely flexible.
+
+## 18. Protect time away from work
+
+Vacation, sick leave, family leave, rest days, and off-hours boundaries should be understood as part of a functioning society, not merely perks for fortunate workers.
+
+Different countries and industries will choose different legal mechanisms.
+
+The principle is simpler:
+
+**people need legitimate time in which employment has no claim on them.**
+
+## 19. Make shorter work a legitimate productivity dividend
+
+As productivity increases, societies and workplaces should be willing to experiment with reduced hours when output, safety, service, and worker well-being allow it.
+
+That could mean shorter weeks, shorter days, seasonal schedules, job sharing, phased retirement, flexible arrangements, or other models.
+
+The doctrine should not declare one universal number of hours without evidence.
+
+The principle is that greater productive capacity should be allowed to create more human time, not only more production.
+
+## 20. Give workers meaningful voice
+
+People should have some ability to influence the conditions under which they spend a large share of their lives.
+
+Worker voice can take many forms:
+
+- direct communication with management
+- elected representatives
+- unions
+- works councils
+- cooperatives
+- employee ownership
+- transparent grievance processes
+- participatory scheduling
+- safety committees
+
+No single model fits every workplace.
+
+But a system where workers have no credible way to influence conditions is not very human-scale.
+
+## 21. Recognize care as essential work
+
+A civilization cannot function without caring for children, sick people, disabled people, older adults, households, and communities.
+
+Policy should avoid treating this labor as economically invisible merely because much of it happens outside formal employment.
+
+Possible responses include paid family leave, caregiver support, childcare systems, respite, flexible work, social insurance, tax policy, community support, or other mechanisms.
+
+The exact mix is political.
+
+The underlying fact is not: care work is real work.
+
+## 22. Reduce the penalty for leaving a bad job
+
+If losing a job immediately threatens healthcare, housing, food, childcare, or every other foundation of life, workers may have very little meaningful freedom to reject abusive or dangerous conditions.
+
+Societies can debate the best mix of wages, savings, insurance, public benefits, portable benefits, unions, family support, and community support.
+
+Human Scale policy should still ask whether people have a realistic ability to say no.
+
+Freedom on paper is weak when exit is impossible in practice.
+
+## 23. Design cities around time as well as distance
+
+Housing, transportation, childcare, schools, jobs, shops, healthcare, parks, and public services should be evaluated partly by how much of people's lives they consume in travel and waiting.
+
+A ten-mile trip can be easy or life-draining depending on the system around it.
+
+Urban design is time policy.
+
+## 24. Use AI to remove bureaucracy before removing purpose
+
+AI and automation should first attack work people commonly experience as needless friction:
+
+- repetitive paperwork
+- duplicate data entry
+- scheduling overhead
+- routine reporting
+- basic administrative coordination
+- dangerous monitoring tasks
+- tedious search and retrieval
+
+Automation should be judged partly by whether the human receives the saved time.
+
+If a tool halves a task and management simply doubles the workload, the technology increased output without increasing freedom.
+
+## 25. Do not make employment the only path to dignity
+
+People who are unemployed, retired, disabled, caregiving, studying, recovering, parenting, volunteering, creating, or between jobs still belong to society.
+
+A culture that asks "What do you do?" and means only "Who pays you?" has narrowed the meaning of contribution.
+
+Human dignity should not rise and fall entirely with labor-market status.
+
+## 26. A Human Scale work test
+
+When evaluating a job, workplace, technology, labor policy, or economic reform, ask:
+
+- Does this work provide adequate material security?
+- How much total time does it consume, including commuting and spillover?
+- Is the schedule predictable enough to build a life around?
+- Does the worker have meaningful voice or agency?
+- Is the work physically and psychologically sustainable?
+- Does it leave time for family, community, health, spirituality, creativity, and rest?
+- Does technology reduce drudgery or merely increase expected output?
+- Who receives the gains when productivity rises?
+- Can a person leave unsafe or degrading work without immediate catastrophe?
+- Does the system recognize valuable work outside formal employment?
+
+No job will maximize every value.
+
+The purpose of the test is to remember that labor policy is ultimately about human lives, not abstract labor inputs.
+
+---
+
+## The deeper idea
+
+A good life contains effort.
+
+It contains responsibility, sacrifice, discipline, deadlines, difficult seasons, and work that simply needs to be done.
+
+Human Scale is not a promise that life can become effortless.
+
+It is a refusal to confuse endless economic activity with purpose.
+
+We need time to raise children.
+
+Time to care for parents.
+
+Time to cook.
+
+Time to grow food.
+
+Time to exercise and sleep.
+
+Time to pray, meditate, make music, read, learn, build, repair, volunteer, celebrate, mourn, organize, sit with friends, and participate in the places where we live.
+
+Some of those activities are work.
+
+Some are rest.
+
+Some are impossible to classify neatly.
+
+That is the point.
+
+A human life is larger than a job description.
+
+Technology can help us produce more with less effort.
+
+If we become wise enough, part of the reward should be getting some of our lives back.
+
+**The purpose of an economy is not to keep everyone busy. It is to help people live.**

--- a/human-scale/work-time/index.html
+++ b/human-scale/work-time/index.html
@@ -1,0 +1,271 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Work & Time — What Is a Human Life For?</title>
+  <meta name="description" content="Chapter 4 of the Human Scale Doctrine: work, time, schedules, commuting, care, automation, worker agency, and the purpose of an economy." />
+  <meta name="theme-color" content="#07111f" />
+  <link rel="icon" href="../../favicon.ico" type="image/x-icon" />
+  <style>
+    :root {
+      color-scheme: dark;
+      --bg: #07111f;
+      --panel: #0c192a;
+      --text: #edf3fa;
+      --muted: #aab9ca;
+      --line: #243850;
+      --sky: #7bcaff;
+      --sun: #ffe18a;
+      --green: #a9ddb0;
+    }
+    * { box-sizing: border-box; }
+    html { scroll-behavior: smooth; }
+    body {
+      margin: 0;
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      color: var(--text);
+      line-height: 1.72;
+      background:
+        radial-gradient(circle at 12% 0%, rgba(123,202,255,.12), transparent 34rem),
+        radial-gradient(circle at 92% 8%, rgba(255,225,138,.08), transparent 32rem),
+        var(--bg);
+    }
+    a { color: var(--sky); }
+    .topbar {
+      width: min(100% - 2rem, 1060px);
+      margin: 0 auto;
+      padding: 1.25rem 0;
+      display: flex;
+      justify-content: space-between;
+      gap: 1rem;
+      color: var(--muted);
+      font-size: .94rem;
+    }
+    .topbar a { color: var(--muted); text-decoration: none; }
+    header {
+      width: min(100% - 2rem, 900px);
+      margin: 0 auto;
+      padding: 5.6rem 0 4.3rem;
+      text-align: center;
+    }
+    .eyebrow {
+      color: var(--sun);
+      text-transform: uppercase;
+      letter-spacing: .16em;
+      font-size: .78rem;
+      font-weight: 850;
+    }
+    h1 {
+      margin: .8rem 0 1rem;
+      font-size: clamp(2.8rem, 8vw, 5.8rem);
+      line-height: .98;
+      letter-spacing: -.05em;
+    }
+    h2 {
+      margin: 0 0 1rem;
+      font-size: clamp(1.85rem, 5vw, 2.8rem);
+      line-height: 1.08;
+      letter-spacing: -.035em;
+    }
+    h3 { margin: 0; font-size: 1.18rem; }
+    p { margin: .9rem 0; }
+    .lead {
+      max-width: 760px;
+      margin: 0 auto;
+      color: var(--muted);
+      font-size: clamp(1.1rem, 2.5vw, 1.35rem);
+    }
+    .thesis {
+      max-width: 800px;
+      margin: 2.2rem auto 0;
+      padding: 1.35rem 1.5rem;
+      border: 1px solid rgba(255,225,138,.28);
+      border-radius: 18px;
+      background: rgba(255,225,138,.05);
+      color: #fff4cf;
+      font-size: clamp(1.2rem, 3vw, 1.65rem);
+      font-weight: 750;
+    }
+    main { width: min(100% - 2rem, 900px); margin: 0 auto; padding-bottom: 6rem; }
+    section { padding: 3.2rem 0; border-top: 1px solid var(--line); }
+    .muted { color: var(--muted); }
+    .callout {
+      margin: 1.6rem 0 0;
+      padding: 1.3rem 1.4rem;
+      border-left: 4px solid var(--sun);
+      border-radius: 0 14px 14px 0;
+      background: var(--panel);
+      font-size: 1.1rem;
+    }
+    .part {
+      color: var(--green);
+      text-transform: uppercase;
+      letter-spacing: .14em;
+      font-size: .78rem;
+      font-weight: 850;
+      margin-bottom: .55rem;
+    }
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 1rem;
+      margin-top: 1.4rem;
+    }
+    .card {
+      padding: 1.25rem;
+      border: 1px solid var(--line);
+      border-radius: 16px;
+      background: linear-gradient(145deg, rgba(17,35,58,.9), rgba(8,19,34,.9));
+    }
+    .card p { color: var(--muted); margin-bottom: 0; }
+    .principle {
+      padding: 1.5rem;
+      border: 1px solid rgba(123,202,255,.26);
+      border-radius: 18px;
+      background: rgba(123,202,255,.045);
+      color: #eaf7ff;
+      font-size: 1.2rem;
+      font-weight: 700;
+    }
+    .test { display: grid; gap: .7rem; margin-top: 1.2rem; }
+    .test div {
+      padding: .95rem 1rem;
+      border: 1px solid var(--line);
+      border-radius: 12px;
+      background: rgba(255,255,255,.025);
+    }
+    .closing { text-align: center; }
+    .closing strong {
+      display: block;
+      max-width: 760px;
+      margin: 2rem auto 0;
+      color: var(--sun);
+      font-size: clamp(1.55rem, 4.5vw, 2.45rem);
+      line-height: 1.15;
+      letter-spacing: -.03em;
+    }
+    footer { border-top: 1px solid var(--line); padding: 2.5rem 1rem 3.5rem; text-align: center; color: var(--muted); }
+    footer a { text-decoration: none; }
+  </style>
+</head>
+<body>
+  <nav class="topbar" aria-label="Page navigation">
+    <a href="../index.html">← Human Scale Doctrine</a>
+    <span>Chapter 4 · Work & Time</span>
+  </nav>
+
+  <header>
+    <div class="eyebrow">Diagnosis · Field Guide · Program</div>
+    <h1>Work & Time</h1>
+    <p class="lead">What is a human life for — and how work, schedules, commuting, care, technology, and economic security shape the time we actually get to live.</p>
+    <div class="thesis">Work should support a human life. A human life should not exist mainly to support work.</div>
+  </header>
+
+  <main>
+    <section>
+      <h2>The starting point</h2>
+      <p>Work can create competence, contribution, income, identity, responsibility, mastery, and meaning.</p>
+      <p>But paid employment is only one kind of useful work. Raising children, caring for people, cooking, gardening, repairing, learning, volunteering, making art, and maintaining community all create value too.</p>
+      <div class="callout">The Human Scale question is not whether people should work. It is <strong>how much of a human life should be consumed by earning the right to keep living it?</strong></div>
+    </section>
+
+    <section>
+      <div class="part">Part I — Diagnosis</div>
+      <h2>Employment can occupy too much of life</h2>
+      <div class="grid">
+        <div class="card"><h3>Time</h3><p>Paid hours can expand through commuting, preparation, recovery, messages, schedule changes, and administrative friction.</p></div>
+        <div class="card"><h3>Predictability</h3><p>Unstable schedules can make family meals, childcare, sleep, classes, worship, exercise, and community hard to sustain.</p></div>
+        <div class="card"><h3>Meaning</h3><p>Good work can provide purpose, but organizations can also use mission or loyalty to normalize unhealthy demands.</p></div>
+        <div class="card"><h3>Distance</h3><p>Long commutes consume time near family and neighbors and make home, work, school, and care harder to connect.</p></div>
+      </div>
+    </section>
+
+    <section>
+      <h2>Productivity should be allowed to create time</h2>
+      <p>Technology can let society produce more with less labor, but those gains do not automatically become free time. They can become more output, higher profits, higher wages, lower prices, or some mixture.</p>
+      <div class="principle">If machines can do more of the work, one possible benefit should be that humans recover some time.</div>
+    </section>
+
+    <section>
+      <h2>Automation is both opportunity and risk</h2>
+      <p>Automation can remove dangerous, repetitive, exhausting, and bureaucratic tasks. It can also remove income, bargaining power, identity, or stability before people have an alternative.</p>
+      <div class="callout">The question is not “automation or no automation.” It is: <strong>which work should machines take, which work should humans keep, and who receives the time and wealth created?</strong></div>
+    </section>
+
+    <section>
+      <div class="part">Part II — Field Guide</div>
+      <h2>Protect the life around the job</h2>
+      <div class="grid">
+        <div class="card"><h3>Audit the real workday</h3><p>Count commuting, preparation, messages, recovery, schedule anxiety, and other hidden time — not only paid hours.</p></div>
+        <div class="card"><h3>Keep time off-limits</h3><p>Protect some hours from employers, customers, notifications, and the pressure to turn every interest into income.</p></div>
+        <div class="card"><h3>Seek agency</h3><p>Evaluate work by schedule control, predictability, commute, strain, learning, usefulness, flexibility, and the ability to leave.</p></div>
+        <div class="card"><h3>Stay useful outside work</h3><p>Cook, repair, grow, care, create, volunteer, learn, build, and keep identities that do not depend on a job title.</p></div>
+        <div class="card"><h3>Control digital spillover</h3><p>Separate truly urgent communication from everything that merely feels urgent where the job allows it.</p></div>
+        <div class="card"><h3>Coordinate shared time</h3><p>Protect recurring meals, evenings, mornings, worship, walks, weekends, or other predictable time with people you love.</p></div>
+      </div>
+    </section>
+
+    <section>
+      <div class="part">Part III — Program</div>
+      <h2>What humane work should protect</h2>
+      <div class="grid">
+        <div class="card"><h3>Material security</h3><p>Work should provide adequate compensation without pretending wages are the only measure of a humane job.</p></div>
+        <div class="card"><h3>Predictable time</h3><p>Workers should have enough schedule stability to build the rest of life wherever the nature of the job allows it.</p></div>
+        <div class="card"><h3>Time away</h3><p>Rest, sick time, family leave, and genuine off-hours should be treated as part of a functioning society.</p></div>
+        <div class="card"><h3>Worker voice</h3><p>People should have credible ways to influence the conditions under which they spend a large part of their lives.</p></div>
+        <div class="card"><h3>Care</h3><p>Childcare, eldercare, disability support, household labor, and other care should not disappear from economic thinking because much of it is unpaid.</p></div>
+        <div class="card"><h3>Real exit</h3><p>Freedom is weak when leaving unsafe or degrading work immediately threatens every foundation of life.</p></div>
+      </div>
+    </section>
+
+    <section>
+      <h2>Shorter work should be a legitimate experiment</h2>
+      <p>When productivity, service, safety, and the nature of the job allow it, workplaces and societies should be willing to test shorter weeks, shorter days, job sharing, seasonal schedules, phased retirement, and other ways of returning time.</p>
+      <p class="muted">The doctrine does not need one universal number of working hours. The principle is that greater productive capacity should be allowed to create more human time, not only more production.</p>
+    </section>
+
+    <section>
+      <h2>AI should remove bureaucracy before purpose</h2>
+      <p>AI is especially promising for repetitive paperwork, duplicate data entry, scheduling overhead, routine reporting, search, retrieval, and administrative coordination.</p>
+      <div class="callout">Automation should be judged partly by whether the human receives the saved time. If a tool halves a task and the workload simply doubles, productivity rose but freedom did not.</div>
+    </section>
+
+    <section>
+      <h2>Urban design is time policy</h2>
+      <p>Housing, transportation, childcare, schools, jobs, healthcare, parks, shops, and public services should be judged partly by how much of people's lives they consume in travel and waiting.</p>
+    </section>
+
+    <section>
+      <h2>A Human Scale work test</h2>
+      <div class="test">
+        <div>Does the work provide adequate material security?</div>
+        <div>How much total time does it consume, including commuting and spillover?</div>
+        <div>Is the schedule predictable enough to build a life around?</div>
+        <div>Does the worker have meaningful voice or agency?</div>
+        <div>Is the work physically and psychologically sustainable?</div>
+        <div>Does it leave time for family, community, health, spirituality, creativity, and rest?</div>
+        <div>Does technology reduce drudgery or mainly increase expected output?</div>
+        <div>Who receives the gains when productivity rises?</div>
+        <div>Can a person leave unsafe or degrading work without immediate catastrophe?</div>
+        <div>Does the system recognize valuable work outside formal employment?</div>
+      </div>
+      <p class="muted">Labor policy is ultimately about human lives, not abstract labor inputs.</p>
+    </section>
+
+    <section class="closing">
+      <h2>The deeper idea</h2>
+      <p>A good life contains effort, responsibility, sacrifice, discipline, deadlines, difficult seasons, and work that simply needs to be done.</p>
+      <p>But we also need time to raise children, care for parents, cook, grow food, exercise, sleep, pray, meditate, make music, read, learn, build, repair, volunteer, celebrate, mourn, organize, and sit with friends.</p>
+      <p>A human life is larger than a job description.</p>
+      <p>Technology can help us produce more with less effort. If we become wise enough, part of the reward should be getting some of our lives back.</p>
+      <strong>The purpose of an economy is not to keep everyone busy. It is to help people live.</strong>
+    </section>
+  </main>
+
+  <footer>
+    <a href="../index.html">Human Scale Doctrine</a> · <a href="../../index.html">tmsteph home</a><br />
+    Living framework · August 2026
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## What changed
- Added Chapter 4 of the Human Scale Doctrine: **Work & Time — What Is a Human Life For?**
- Added Markdown source and a mobile-friendly public chapter page.
- Updated the doctrine to v0.6 and linked Chapter 4 from the main Human Scale page.
- Developed work as one form of human contribution rather than the whole of human worth.
- Covered predictable scheduling, hidden time costs, commuting, caregiving, worker agency, shorter-work experiments, automation, AI, and the distribution of productivity gains.

## Why
The first three chapters establish human needs, living-world participation, and community. Chapter 4 addresses the constraint that can make all three difficult: when employment consumes the time and energy needed for family, health, land, community, spiritual life, creativity, and rest.

## Scope
The chapter keeps the simple **Diagnosis → Field Guide → Program** structure and avoids declaring one universal labor model or workweek.