### PR TITLE
add Technology chapter

### DIFF
--- a/human-scale/doctrine.md
+++ b/human-scale/doctrine.md
@@ -1,6 +1,6 @@
 # The Human Scale Doctrine
 
-**Version 0.6 — August 2026**
+**Version 0.7 — August 2026**
 
 > Humanity became powerful faster than it became wise.
 
@@ -95,6 +95,7 @@ A civilization is progressing when more people can:
 - create rather than merely consume
 - work without surrendering their entire waking lives
 - retain meaningful time that is not claimed by employment or constant economic activity
+- use powerful technology without surrendering attention, ownership, judgment, or the ability to leave
 - access nature and public space
 - participate directly in the living world through soil, plants, food, animals, and stewardship
 - obtain food, shelter, education, and healthcare without permanent desperation
@@ -112,6 +113,7 @@ It argues for **human-compatible technology**:
 - open-source software and hardware
 - distributed networks
 - repairable devices
+- interoperable systems and portable data
 - local and flexible manufacturing
 - automation of dangerous, repetitive, and bureaucratic labor
 - AI that expands human agency rather than replacing human judgment everywhere
@@ -174,11 +176,15 @@ The third chapter explores repeated relationships, neighbors, shared meals and w
 
 The fourth chapter asks how much of life employment should consume, distinguishes paid work from human contribution, and explores predictable time, worker agency, care, commuting, automation, shorter-work experiments, and the idea that productivity should sometimes give time back.
 
+### 5. [Technology — Tools That Serve Life](technology/index.html)
+
+The fifth chapter asks how technology can expand human capability without demanding attention, dependence, lock-in, or loss of judgment. It explores repair, interoperability, open systems, AI, automation, resilience, local capability, and technology that knows when to get out of the way.
+
 Long chapters are optional depth. The doctrine itself should remain readable without them.
 
 ## Where This Can Grow
 
-Future subjects may include technology, energy, economics, education, artificial intelligence, spirituality, governance, food, architecture, transportation, family, health, ecology, and open source.
+Future subjects may include energy, economics, education, artificial intelligence, spirituality, governance, food, architecture, transportation, family, health, ecology, and open source.
 
 We do not need a complete system before we can learn, write, test ideas, or act.
 
@@ -203,6 +209,8 @@ Among the questions still to explore:
 - How should ownership change in a highly automated economy?
 - What work should humans continue doing even when machines can do it?
 - How should gains from productivity be divided among wages, prices, profits, public benefits, and human time?
+- What forms of technological openness most effectively preserve agency without blocking safety, reliability, or innovation?
+- How should AI preserve human judgment when systems become increasingly capable of acting on our behalf?
 - How can dense cities become deeply connected to nature?
 - How do we preserve scientific rigor while allowing spiritual pluralism?
 - What should children learn in a civilization built around human flourishing?

--- a/human-scale/index.html
+++ b/human-scale/index.html
@@ -197,7 +197,7 @@
 <body>
   <nav class="topbar" aria-label="Page navigation">
     <a href="../index.html">← tmsteph home</a>
-    <span>Living doctrine · v0.6</span>
+    <span>Living doctrine · v0.7</span>
   </nav>
 
   <header>
@@ -260,12 +260,12 @@
 
     <section>
       <h2>What progress should mean</h2>
-      <p>Progress is more than GDP, speed, scale, convenience, or computational power. A civilization is progressing when people have healthier bodies, deeper relationships, durable community, meaningful work, time that is actually theirs, agency, access to nature and living land, material security, room to create, and a living world to pass on.</p>
+      <p>Progress is more than GDP, speed, scale, convenience, or computational power. A civilization is progressing when people have healthier bodies, deeper relationships, durable community, meaningful work, time that is actually theirs, agency over the technology around them, access to nature and living land, material security, room to create, and a living world to pass on.</p>
     </section>
 
     <section>
       <h2>The direction</h2>
-      <p><strong>Technology:</strong> open, repairable, distributed, resilient, and quiet enough to disappear when it is not needed.</p>
+      <p><strong>Technology:</strong> open, repairable, interoperable, resilient, agency-expanding, and quiet enough to disappear when it is not needed.</p>
       <p><strong>Society:</strong> stronger families and communities, repeated local relationships, meaningful public space, access to living land, time for care, rest and civic life, pluralism, and power that stays understandable and accountable.</p>
       <p><strong>Inner life:</strong> room for science and reason alongside prayer, meditation, yoga, art, music, philosophy, nature, and the human search for meaning.</p>
       <div class="callout">The goal is not maximum technology. The goal is the right technology in the right place, serving life.</div>
@@ -278,6 +278,7 @@
       <a class="chapter" href="land-life/index.html"><strong>Chapter 2: Land & Life — Reconnecting Humans to the Living World →</strong><span>Land access, gardens, food forests, plants, animals, embodied practice, and the idea that living systems belong inside everyday infrastructure.</span></a>
       <a class="chapter" href="community/index.html"><strong>Chapter 3: Community — The Human Need to Belong →</strong><span>Neighbors, repeated relationships, shared meals and work, third places, caregiving, local participation, and belonging without captivity.</span></a>
       <a class="chapter" href="work-time/index.html"><strong>Chapter 4: Work & Time — What Is a Human Life For? →</strong><span>Paid work and human contribution, predictable time, commuting, care, worker agency, automation, and the possibility that productivity should give some of our lives back.</span></a>
+      <a class="chapter" href="technology/index.html"><strong>Chapter 5: Technology — Tools That Serve Life →</strong><span>Attention, repairability, interoperability, AI, automation, resilience, open systems, and tools that expand human capability without becoming the whole environment.</span></a>
     </section>
 
     <section>
@@ -291,7 +292,7 @@
       <p>We can keep the knowledge. We can keep the science. We can keep the computers.</p>
       <p>And we can use them to build a civilization in which people once again belong to their bodies, their communities, and the Earth.</p>
       <strong>The village and the computer can coexist.</strong>
-      <p class="version">Version 0.6 · A living doctrine, expected to change as its ideas are challenged, tested, and refined.</p>
+      <p class="version">Version 0.7 · A living doctrine, expected to change as its ideas are challenged, tested, and refined.</p>
     </section>
   </main>
 

--- a/human-scale/technology/chapter.md
+++ b/human-scale/technology/chapter.md
@@ -1,0 +1,448 @@
+# Chapter 5: Technology — Tools That Serve Life
+
+**Human Scale Doctrine — Diagnosis / Field Guide / Program**
+
+> Technology should expand human capability without requiring human captivity.
+
+Human beings make tools.
+
+A tool can extend the hand, the eye, the memory, the voice, the imagination, the strength of the body, and the reach of a community.
+
+Fire, writing, roads, printing, electricity, medicine, radio, computers, networks, and artificial intelligence have all changed what humans can do.
+
+The Human Scale Doctrine is not an argument against technological advancement.
+
+It is an argument against treating technological advancement as self-justifying.
+
+A technology can be impressive, profitable, efficient, and widely adopted while still making people more distracted, dependent, opaque to themselves, powerless to repair what they own, or unable to leave the systems on which ordinary life depends.
+
+The right question is not simply:
+
+**Can we build it?**
+
+The better questions are:
+
+**What human purpose does it serve? What does it ask from us in return? Who controls it? Can we understand it? Can we leave it? And does it make human life larger or smaller?**
+
+---
+
+# Part I — Diagnosis
+
+## 1. Technology becomes environment
+
+A hammer is something we pick up and put down.
+
+A transportation network, smartphone, payment system, social platform, workplace software stack, or AI infrastructure can become part of the environment through which daily life must pass.
+
+Once technology becomes infrastructure, its design choices stop being merely personal preferences.
+
+They can influence how people communicate, work, travel, buy food, access government, learn, date, raise children, organize politically, find information, and spend attention.
+
+Technology therefore deserves to be evaluated partly as **environmental design for human beings.**
+
+## 2. Convenience can hide dependence
+
+Convenience is real progress when it removes unnecessary difficulty.
+
+But convenience can also trade away competence, choice, repairability, privacy, resilience, or understanding without making the trade obvious.
+
+A system may become easier to use while becoming harder to leave.
+
+A device may become more polished while becoming less repairable.
+
+A service may remove friction while creating a new dependency on one company, account, network connection, subscription, or proprietary format.
+
+The Human Scale question is not whether convenience is bad.
+
+It is whether the convenience leaves the person **more capable or merely more dependent.**
+
+## 3. Attention became an economic resource
+
+Digital technology can educate, connect, entertain, organize, create, translate, navigate, and provide access to knowledge at extraordinary scale.
+
+It can also create environments where the user's attention is continually requested, measured, predicted, and competed for.
+
+Notifications, feeds, recommendations, streaks, autoplay, alerts, badges, rankings, and endless content are not merely interface details when they shape hours of daily life.
+
+A Human Scale technology should not require a person to fight the interface all day merely to preserve the ability to think.
+
+## 4. The most powerful systems can become difficult to understand
+
+Modern systems often require specialization. Complexity is not automatically a failure.
+
+A power grid, aircraft, hospital, semiconductor fab, or large software platform cannot be fully understood by every person who uses it.
+
+But there is a difference between necessary complexity and unnecessary opacity.
+
+People should be able to understand enough about important systems to know:
+
+- what the system is doing
+- what information it uses
+- what choices are available
+- who controls it
+- how to leave or switch
+- what happens when it fails
+- where accountability lives
+
+Human Scale does not require every system to be simple.
+
+It asks complex systems to remain **legible at the level where ordinary people must make decisions.**
+
+## 5. Ownership can become permission
+
+A person may buy a device but still be unable to repair it, modify it, install alternative software, obtain parts, move data, or continue using it after a remote service disappears.
+
+This weakens the ordinary meaning of ownership.
+
+The deeper Human Scale principle is not that every technology must be open source.
+
+It is that ownership and access should come with meaningful agency whenever technically and safely possible.
+
+Repair, interoperability, data portability, documented interfaces, replaceable components, local control, and long-lived standards can all support that agency.
+
+## 6. Centralization can create extraordinary capability and extraordinary fragility
+
+Large technological systems can achieve things small systems cannot.
+
+Global communication, scientific computing, chip fabrication, satellite networks, large language models, medical research, and major infrastructure may depend on large institutions and concentrated expertise.
+
+Scale is sometimes justified.
+
+But concentration can also create single points of failure, lock-in, surveillance power, weak bargaining positions, and systems where ordinary users have little meaningful alternative.
+
+The Human Scale principle remains:
+
+**Scale should have to justify itself.**
+
+Use large systems where scale creates real value. Preserve local control, open interfaces, alternatives, and fallbacks where possible.
+
+## 7. Artificial intelligence changes the relationship between humans and tools
+
+Traditional tools usually wait for a person to decide what to do.
+
+AI systems can increasingly generate, recommend, summarize, search, classify, predict, plan, automate, communicate, and act on behalf of people.
+
+That can greatly expand human capability.
+
+It also raises a new question:
+
+**Does the system strengthen human judgment, or slowly make human judgment unnecessary to operate the surrounding world?**
+
+The Human Scale goal should not be to keep humans manually performing every task.
+
+It should be to automate in ways that preserve agency, understanding, meaningful choice, and the ability to intervene.
+
+## 8. Technology can genuinely liberate
+
+A critique of technology that ignores its benefits becomes nostalgia.
+
+Technology has reduced physical drudgery, expanded communication, improved accessibility, preserved knowledge, enabled remote collaboration, supported medical care, reduced some dangers, and allowed people to create things that would once have required enormous institutions.
+
+Open-source software can let a small team build on the work of thousands.
+
+Digital fabrication can move some production closer to where it is needed.
+
+AI can help a person learn, write, program, organize, translate, research, and navigate bureaucracy.
+
+The doctrine should preserve this liberating potential.
+
+The goal is not less capability.
+
+The goal is **capability without unnecessary domination.**
+
+---
+
+# Part II — Field Guide
+
+## 9. Choose technology by what it does to your life
+
+Do not evaluate a tool only by features.
+
+Ask what happens after months of use.
+
+Does it save time?
+
+Does it create more work?
+
+Does it make you more competent?
+
+Does it interrupt you?
+
+Does it help relationships?
+
+Does it replace something you still value?
+
+Does it create a new recurring cost?
+
+Does it make leaving difficult?
+
+A useful tool should solve more problems than it quietly creates.
+
+## 10. Protect attention by changing the environment
+
+Willpower should not be the only defense against software designed to request attention continually.
+
+Turn off notifications that do not deserve interruption. Remove unnecessary badges. Keep some devices away from meals, sleep, prayer, conversation, exercise, and time outdoors. Use full-screen or focused modes when doing one thing matters.
+
+Do not treat every communication channel as equally urgent.
+
+The goal is not digital purity.
+
+It is to make attention **intentional enough that a person can still choose what their mind is doing.**
+
+## 11. Prefer tools with an exit
+
+Whenever practical, favor tools that make it possible to:
+
+- export your data
+- use standard formats
+- move to another provider
+- continue working offline when appropriate
+- repair or replace components
+- use alternative clients or software
+- understand the basic failure mode
+
+You will not always be able to choose the most open system.
+
+The important habit is noticing the exit cost before dependence becomes deep.
+
+## 12. Keep some competence outside the tool
+
+GPS is useful. It is still good to know the basic geography of where you live.
+
+Calculators are useful. It is still good to understand arithmetic.
+
+AI is useful. It is still good to learn how to think, write, judge, and make decisions.
+
+Automation should not require preserving every obsolete manual skill.
+
+But when a skill is central to judgment, safety, identity, or resilience, preserving some human competence matters.
+
+Use tools to extend ability, not automatically to erase it.
+
+## 13. Use AI as a collaborator before using it as a substitute for yourself
+
+AI can help explore ideas, find weaknesses, explain unfamiliar material, draft alternatives, automate repetitive work, surface context, and help turn intentions into action.
+
+A strong use of AI often leaves the human more capable of understanding and deciding.
+
+A weaker use can produce an answer the person cannot evaluate and gradually remove the person from the activity entirely.
+
+The right balance will vary by task.
+
+A useful question is:
+
+**After using this system for a year, am I more capable of directing my life, or merely more dependent on the system directing parts of it for me?**
+
+## 14. Let technology disappear sometimes
+
+A good tool does not need to become an identity.
+
+Use the map, then look at the street.
+
+Use the camera, then watch the child.
+
+Use the group chat to organize the meal, then put the phone away at the table.
+
+Use AI to reduce paperwork, then spend the saved time with people, in the garden, making music, resting, learning, building, or doing work that matters.
+
+The highest form of technological success may sometimes be that the technology quietly completes its function and leaves the human world visible again.
+
+---
+
+# Part III — Program
+
+## 15. Make repair normal
+
+A repairable society wastes less knowledge and gives people more control over the things they depend on.
+
+Public policy, industry standards, education, and product design can support:
+
+- access to parts
+- service information
+- replaceable components where practical
+- independent repair
+- reasonable product lifetimes
+- software support that does not unnecessarily strand functioning hardware
+
+Not every product can be repaired safely by every person.
+
+Safety and technical constraints are real.
+
+But difficulty should not be manufactured merely to protect control over the customer.
+
+## 16. Make interoperability a default goal
+
+People should not lose their social graph, documents, purchases, creative work, business history, or public identity merely because they change tools.
+
+Open standards, documented protocols, portable data, interoperable services, and competitive clients can make digital systems more like infrastructure and less like private kingdoms.
+
+Interoperability will not solve every monopoly or governance problem.
+
+It can still reduce the cost of leaving.
+
+And the ability to leave is an important form of freedom.
+
+## 17. Build public digital infrastructure where it makes sense
+
+Some digital systems function increasingly like roads, libraries, identity infrastructure, communication networks, payment rails, public records, maps, or civic spaces.
+
+Where a digital layer becomes essential to participation in society, governments and communities should at least consider whether parts of that layer should use open standards, public-interest governance, transparent procurement, reusable software, or infrastructure that does not depend entirely on one vendor.
+
+Public does not automatically mean good.
+
+Private does not automatically mean bad.
+
+The test is whether essential infrastructure remains accountable, resilient, understandable, and open to alternatives.
+
+## 18. Design for calm by default
+
+A person's attention should not be treated as unlimited raw material.
+
+Humane defaults can include:
+
+- notifications off unless genuinely useful
+- clear stopping points
+- chronological or user-controlled views where appropriate
+- meaningful controls over recommendation systems
+- fewer deceptive interface patterns
+- understandable privacy choices
+- special caution for systems used by children
+
+People can still choose stimulating, immersive, entertaining experiences.
+
+The point is that compulsion should not be the default business model of every digital environment.
+
+## 19. AI should multiply agency
+
+AI should be judged partly by whether it helps ordinary people do things that previously required large amounts of money, expertise, bureaucracy, or institutional access.
+
+Useful directions include:
+
+- tutoring and explanation
+- translation
+- accessibility
+- navigating forms and bureaucracy
+- programming and technical creation
+- research assistance
+- small-business operations
+- civic understanding
+- creative tools
+- personal organization
+- reducing repetitive administrative work
+
+But an AI that acts for a person should remain accountable to that person.
+
+People should be able to understand important actions, set boundaries, review consequential decisions, correct the system, and revoke authority.
+
+## 20. Automation should return something to humans
+
+Automation can produce lower prices, higher output, higher wages, profits, public revenue, better services, shorter work, or some combination.
+
+The distribution is not technologically predetermined.
+
+Human Scale policy should ask explicitly:
+
+**Who receives the benefit when a machine removes human labor?**
+
+If automation eliminates drudgery but people receive neither time, security, ownership, nor improved services, then technological progress may be real while human progress remains incomplete.
+
+## 21. Preserve fallback modes
+
+A resilient society should not make every essential function depend on one cloud account, one company, one wireless connection, one payment network, or one software service.
+
+Where consequences are serious, design for graceful failure.
+
+That may include offline capability, local copies, physical controls, manual overrides, multiple providers, open protocols, backup power, paper procedures, or human support.
+
+Redundancy can look inefficient on a spreadsheet.
+
+During failure, redundancy becomes capacity.
+
+## 22. Use technology to strengthen local capability
+
+Advanced technology does not have to centralize everything.
+
+It can also help distribute capability through:
+
+- open-source tools
+- digital fabrication
+- local energy systems
+- community networks
+- small-scale manufacturing
+- shared technical knowledge
+- repair shops and makerspaces
+- local food and water monitoring
+- cooperative platforms
+- tools that help small organizations operate with less bureaucracy
+
+The village and the computer can reinforce each other.
+
+## 23. Account for the physical world behind the digital one
+
+Digital services still depend on mines, factories, chips, servers, cables, energy, cooling, buildings, shipping, labor, and eventual disposal.
+
+A Human Scale technological policy should care about durability, energy use, repair, reuse, materials, working conditions, and end-of-life systems.
+
+The cloud is physical infrastructure with a friendly name.
+
+## 24. A Human Scale technology test
+
+When evaluating a device, platform, AI system, infrastructure project, or technological policy, ask:
+
+- What human need or purpose does it serve?
+- Does it save human time or merely create new expectations?
+- Does it strengthen or weaken human agency?
+- What does it do to attention?
+- Can the user understand the important choices and consequences?
+- Can the user repair, modify, export, switch, or leave where appropriate?
+- Does it preserve meaningful human judgment in consequential decisions?
+- What happens when the network, company, model, account, or power fails?
+- Who controls the system and who receives the benefits?
+- Does it strengthen local capability or create unnecessary dependence?
+- What physical and ecological costs sit behind it?
+- Does it ultimately leave more room for human life?
+
+A technology does not need a perfect score.
+
+The test exists to ask questions that feature lists and market adoption do not answer.
+
+---
+
+## The deeper idea
+
+Human beings have always transformed themselves through tools.
+
+We should keep doing so.
+
+Build better medicine.
+
+Build better energy systems.
+
+Build computers that help people create.
+
+Build robots that take dangerous work.
+
+Build AI that helps ordinary people understand and shape systems that once excluded them.
+
+Build communication tools that help communities organize.
+
+Build open machines people can repair, learn from, adapt, and share.
+
+But do not confuse a world full of machines with a world improved for humans.
+
+The purpose of technology is not to occupy every remaining piece of life.
+
+The purpose is to give humans greater capacity to live well.
+
+The most advanced civilization may not be the one where technology is most visible.
+
+It may be the one where extraordinary technological capability works quietly underneath healthy bodies, strong communities, living landscapes, meaningful work, free time, creativity, spiritual life, and human relationships.
+
+Use the machine.
+
+Receive the benefit.
+
+Then return to life.
+
+**The best technology expands the human world without replacing it.**

--- a/human-scale/technology/index.html
+++ b/human-scale/technology/index.html
@@ -1,0 +1,280 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Technology — Tools That Serve Life</title>
+  <meta name="description" content="Chapter 5 of the Human Scale Doctrine: attention, agency, repairability, open systems, AI, automation, resilience, and technology that serves human life." />
+  <meta name="theme-color" content="#07111f" />
+  <link rel="icon" href="../../favicon.ico" type="image/x-icon" />
+  <style>
+    :root {
+      color-scheme: dark;
+      --bg: #07111f;
+      --panel: #0c192a;
+      --text: #edf3fa;
+      --muted: #aab9ca;
+      --line: #243850;
+      --sky: #7bcaff;
+      --sun: #ffe18a;
+      --green: #a9ddb0;
+    }
+    * { box-sizing: border-box; }
+    html { scroll-behavior: smooth; }
+    body {
+      margin: 0;
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      color: var(--text);
+      line-height: 1.72;
+      background:
+        radial-gradient(circle at 12% 0%, rgba(123,202,255,.14), transparent 34rem),
+        radial-gradient(circle at 92% 8%, rgba(169,221,176,.08), transparent 32rem),
+        var(--bg);
+    }
+    a { color: var(--sky); }
+    .topbar {
+      width: min(100% - 2rem, 1060px);
+      margin: 0 auto;
+      padding: 1.25rem 0;
+      display: flex;
+      justify-content: space-between;
+      gap: 1rem;
+      color: var(--muted);
+      font-size: .94rem;
+    }
+    .topbar a { color: var(--muted); text-decoration: none; }
+    header {
+      width: min(100% - 2rem, 900px);
+      margin: 0 auto;
+      padding: 5.6rem 0 4.3rem;
+      text-align: center;
+    }
+    .eyebrow {
+      color: var(--sky);
+      text-transform: uppercase;
+      letter-spacing: .16em;
+      font-size: .78rem;
+      font-weight: 850;
+    }
+    h1 {
+      margin: .8rem 0 1rem;
+      font-size: clamp(2.8rem, 8vw, 5.8rem);
+      line-height: .98;
+      letter-spacing: -.05em;
+    }
+    h2 {
+      margin: 0 0 1rem;
+      font-size: clamp(1.85rem, 5vw, 2.8rem);
+      line-height: 1.08;
+      letter-spacing: -.035em;
+    }
+    h3 { margin: 0; font-size: 1.18rem; }
+    p { margin: .9rem 0; }
+    .lead {
+      max-width: 760px;
+      margin: 0 auto;
+      color: var(--muted);
+      font-size: clamp(1.1rem, 2.5vw, 1.35rem);
+    }
+    .thesis {
+      max-width: 800px;
+      margin: 2.2rem auto 0;
+      padding: 1.35rem 1.5rem;
+      border: 1px solid rgba(123,202,255,.3);
+      border-radius: 18px;
+      background: rgba(123,202,255,.055);
+      color: #eaf7ff;
+      font-size: clamp(1.2rem, 3vw, 1.65rem);
+      font-weight: 750;
+    }
+    main { width: min(100% - 2rem, 900px); margin: 0 auto; padding-bottom: 6rem; }
+    section { padding: 3.2rem 0; border-top: 1px solid var(--line); }
+    .muted { color: var(--muted); }
+    .callout {
+      margin: 1.6rem 0 0;
+      padding: 1.3rem 1.4rem;
+      border-left: 4px solid var(--sky);
+      border-radius: 0 14px 14px 0;
+      background: var(--panel);
+      font-size: 1.1rem;
+    }
+    .part {
+      color: var(--green);
+      text-transform: uppercase;
+      letter-spacing: .14em;
+      font-size: .78rem;
+      font-weight: 850;
+      margin-bottom: .55rem;
+    }
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 1rem;
+      margin-top: 1.4rem;
+    }
+    .card {
+      padding: 1.25rem;
+      border: 1px solid var(--line);
+      border-radius: 16px;
+      background: linear-gradient(145deg, rgba(17,35,58,.9), rgba(8,19,34,.9));
+    }
+    .card p { color: var(--muted); margin-bottom: 0; }
+    .principle {
+      padding: 1.5rem;
+      border: 1px solid rgba(255,225,138,.26);
+      border-radius: 18px;
+      background: rgba(255,225,138,.045);
+      color: #fff4cf;
+      font-size: 1.2rem;
+      font-weight: 700;
+    }
+    .test { display: grid; gap: .7rem; margin-top: 1.2rem; }
+    .test div {
+      padding: .95rem 1rem;
+      border: 1px solid var(--line);
+      border-radius: 12px;
+      background: rgba(255,255,255,.025);
+    }
+    .closing { text-align: center; }
+    .closing strong {
+      display: block;
+      max-width: 760px;
+      margin: 2rem auto 0;
+      color: var(--sun);
+      font-size: clamp(1.55rem, 4.5vw, 2.45rem);
+      line-height: 1.15;
+      letter-spacing: -.03em;
+    }
+    footer { border-top: 1px solid var(--line); padding: 2.5rem 1rem 3.5rem; text-align: center; color: var(--muted); }
+    footer a { text-decoration: none; }
+  </style>
+</head>
+<body>
+  <nav class="topbar" aria-label="Page navigation">
+    <a href="../index.html">← Human Scale Doctrine</a>
+    <span>Chapter 5 · Technology</span>
+  </nav>
+
+  <header>
+    <div class="eyebrow">Diagnosis · Field Guide · Program</div>
+    <h1>Technology</h1>
+    <p class="lead">Tools that serve life — attention, agency, repairability, open systems, AI, automation, resilience, and the right relationship between humans and machines.</p>
+    <div class="thesis">Technology should expand human capability without requiring human captivity.</div>
+  </header>
+
+  <main>
+    <section>
+      <h2>The starting point</h2>
+      <p>Human beings make tools. Tools extend the hand, eye, memory, voice, imagination, strength, and reach of a community.</p>
+      <p>The Human Scale Doctrine is not against technological advancement. It is against treating advancement as self-justifying.</p>
+      <div class="callout">The better question is not only <strong>“Can we build it?”</strong> but “What human purpose does it serve, what does it ask from us, who controls it, and can we leave it?”</div>
+    </section>
+
+    <section>
+      <div class="part">Part I — Diagnosis</div>
+      <h2>Technology becomes environment</h2>
+      <p>Some technologies are tools we pick up and put down. Others become the environment through which daily life must pass: phones, payment systems, transportation networks, platforms, workplace software, and AI.</p>
+      <div class="grid">
+        <div class="card"><h3>Attention</h3><p>Digital systems can help us think and connect, but can also compete continuously for the mind.</p></div>
+        <div class="card"><h3>Dependence</h3><p>Convenience can quietly trade away competence, repairability, privacy, resilience, or the ability to leave.</p></div>
+        <div class="card"><h3>Opacity</h3><p>Necessary complexity is real, but important systems should remain legible enough for people to understand choices, control, and failure.</p></div>
+        <div class="card"><h3>Scale</h3><p>Large systems can create extraordinary capability, but concentration can also create lock-in and single points of failure.</p></div>
+      </div>
+    </section>
+
+    <section>
+      <h2>Ownership should mean agency</h2>
+      <p>A person may buy a device but still be unable to repair it, modify it, install alternatives, move data, or keep using it when a remote service disappears.</p>
+      <div class="principle">Repair, interoperability, data portability, documented interfaces, replaceable components, local control, and long-lived standards can make ownership more real.</div>
+    </section>
+
+    <section>
+      <h2>AI changes the relationship between humans and tools</h2>
+      <p>AI can generate, recommend, summarize, search, classify, predict, plan, communicate, and act on our behalf.</p>
+      <div class="callout">The question is whether AI strengthens human judgment and capability — or slowly makes human judgment unnecessary to operate the surrounding world.</div>
+    </section>
+
+    <section>
+      <h2>Technology can genuinely liberate</h2>
+      <p>A useful critique of technology must preserve its benefits. Tools can reduce drudgery, expand accessibility, connect people, spread knowledge, support medicine, help small teams create, and give ordinary people capabilities once reserved for large institutions.</p>
+      <p>The goal is not less capability. It is <strong>capability without unnecessary domination.</strong></p>
+    </section>
+
+    <section>
+      <div class="part">Part II — Field Guide</div>
+      <h2>Use tools without letting them become the whole environment</h2>
+      <div class="grid">
+        <div class="card"><h3>Judge the aftermath</h3><p>Ask what happens after months of use: does the tool save time, build competence, support relationships, or create new burdens?</p></div>
+        <div class="card"><h3>Protect attention</h3><p>Turn off unnecessary interruptions and preserve spaces where nothing is demanding a click, reaction, or response.</p></div>
+        <div class="card"><h3>Prefer an exit</h3><p>Favor standard formats, exports, offline modes, repairable parts, alternative software, and tools that do not trap your work.</p></div>
+        <div class="card"><h3>Keep competence</h3><p>When a skill matters for judgment, safety, identity, or resilience, preserve enough human ability to understand what the tool is doing.</p></div>
+        <div class="card"><h3>Use AI to extend yourself</h3><p>Let AI explain, draft, automate, organize, and challenge ideas while keeping consequential judgment and direction human.</p></div>
+        <div class="card"><h3>Let it disappear</h3><p>Use the map, then look at the street. Use the group chat, then eat together. Use AI, then spend the saved time living.</p></div>
+      </div>
+    </section>
+
+    <section>
+      <div class="part">Part III — Program</div>
+      <h2>Build technological freedom into the system</h2>
+      <div class="grid">
+        <div class="card"><h3>Repair</h3><p>Support access to parts, service information, independent repair, reasonable lifetimes, and software support that does not strand useful hardware.</p></div>
+        <div class="card"><h3>Interoperability</h3><p>Use open standards, portable data, documented protocols, and competitive clients to lower the cost of leaving.</p></div>
+        <div class="card"><h3>Calm defaults</h3><p>Design notifications, recommendations, privacy choices, stopping points, and child-facing systems around human attention rather than maximum engagement.</p></div>
+        <div class="card"><h3>Public-interest infrastructure</h3><p>Where digital systems become essential, consider open standards, accountable governance, reusable software, and alternatives to total vendor dependence.</p></div>
+        <div class="card"><h3>Resilience</h3><p>Preserve offline modes, backups, local copies, manual overrides, multiple providers, and graceful failure where consequences are serious.</p></div>
+        <div class="card"><h3>Local capability</h3><p>Use open source, fabrication, community networks, repair shops, makerspaces, local energy, and shared technical knowledge to distribute capability.</p></div>
+      </div>
+    </section>
+
+    <section>
+      <h2>AI should multiply agency</h2>
+      <p>AI is most human-compatible when it helps ordinary people do things that previously demanded large amounts of money, expertise, bureaucracy, or institutional access.</p>
+      <p>When AI acts on behalf of a person, the person should be able to set boundaries, review consequential actions, correct the system, and revoke authority.</p>
+    </section>
+
+    <section>
+      <h2>Automation should return something to humans</h2>
+      <p>Automation can create lower prices, higher output, wages, profits, public revenue, better services, shorter work, or some combination. The distribution is not technologically predetermined.</p>
+      <div class="callout">Human Scale asks explicitly: <strong>who receives the benefit when a machine removes human labor?</strong></div>
+    </section>
+
+    <section>
+      <h2>The digital world is still physical</h2>
+      <p>Chips, servers, cables, mines, factories, energy, cooling, shipping, labor, and disposal sit behind digital services. Durability, repair, reuse, materials, energy, and working conditions belong inside technological thinking too.</p>
+    </section>
+
+    <section>
+      <h2>A Human Scale technology test</h2>
+      <div class="test">
+        <div>What human need or purpose does it serve?</div>
+        <div>Does it save human time or create new expectations?</div>
+        <div>Does it strengthen or weaken agency?</div>
+        <div>What does it do to attention?</div>
+        <div>Can people understand the important choices and consequences?</div>
+        <div>Can users repair, export, switch, modify, or leave where appropriate?</div>
+        <div>Does it preserve meaningful human judgment in consequential decisions?</div>
+        <div>What happens when the network, company, model, account, or power fails?</div>
+        <div>Who controls the system and receives the benefits?</div>
+        <div>Does it strengthen local capability or create unnecessary dependence?</div>
+        <div>What physical and ecological costs sit behind it?</div>
+        <div>Does it ultimately leave more room for human life?</div>
+      </div>
+      <p class="muted">A technology does not need a perfect score. The test asks questions that feature lists and adoption numbers often do not.</p>
+    </section>
+
+    <section class="closing">
+      <h2>The deeper idea</h2>
+      <p>Build better medicine. Better energy. Better computers. Robots that take dangerous work. AI that helps people learn, create, organize, and understand systems that once excluded them.</p>
+      <p>But do not confuse a world full of machines with a world improved for humans.</p>
+      <p>The most advanced civilization may be one where extraordinary technological capability works quietly underneath healthy bodies, strong communities, living landscapes, meaningful work, free time, creativity, spiritual life, and human relationships.</p>
+      <p>Use the machine. Receive the benefit. Then return to life.</p>
+      <strong>The best technology expands the human world without replacing it.</strong>
+    </section>
+  </main>
+
+  <footer>
+    <a href="../index.html">Human Scale Doctrine</a> · <a href="../../index.html">tmsteph home</a><br />
+    Living framework · August 2026
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## What changed
- Added Chapter 5 of the Human Scale Doctrine: **Technology — Tools That Serve Life**.
- Added Markdown source and a mobile-friendly public chapter page.
- Updated the doctrine to v0.7 and linked Chapter 5 from the main Human Scale page.
- Developed technology around attention, agency, repairability, interoperability, open systems, AI, automation, resilience, local capability, and ecological cost.
- Added the principle that technological freedom includes the ability to export, repair, switch, leave, and keep functioning when systems fail.

## Why
The first four chapters establish human nature, living-world participation, community, and time. Chapter 5 asks what role technology should play inside that life: expanding capability without becoming the whole environment or eroding human agency.

## Scope
The chapter keeps the simple **Diagnosis → Field Guide → Program** structure and adds no new overarching framework.