### PR TITLE
add Energy chapter

### DIFF
--- a/human-scale/doctrine.md
+++ b/human-scale/doctrine.md
@@ -1,6 +1,6 @@
 # The Human Scale Doctrine
 
-**Version 0.7 — August 2026**
+**Version 0.8 — August 2026**
 
 > Humanity became powerful faster than it became wise.
 
@@ -96,9 +96,10 @@ A civilization is progressing when more people can:
 - work without surrendering their entire waking lives
 - retain meaningful time that is not claimed by employment or constant economic activity
 - use powerful technology without surrendering attention, ownership, judgment, or the ability to leave
+- rely on modern energy without accepting permanent pollution, waste, fragility, or total dependence
 - access nature and public space
 - participate directly in the living world through soil, plants, food, animals, and stewardship
-- obtain food, shelter, education, and healthcare without permanent desperation
+- obtain food, shelter, education, healthcare, and essential energy without permanent desperation
 - participate in culture and community
 - develop spiritually, intellectually, emotionally, and creatively
 - leave a healthy world to the next generation
@@ -109,7 +110,7 @@ This doctrine is not anti-technology.
 
 It argues for **human-compatible technology**:
 
-- renewable and locally resilient energy
+- clean, reliable, abundant, and locally resilient energy
 - open-source software and hardware
 - distributed networks
 - repairable devices
@@ -140,6 +141,7 @@ It should favor:
 - cooperative creation
 - meaningful public spaces and third places
 - meaningful access to living land
+- resilient local capability connected to larger shared systems
 - decentralized political and economic power
 - cultural pluralism
 - freedom of belief
@@ -180,11 +182,15 @@ The fourth chapter asks how much of life employment should consume, distinguishe
 
 The fifth chapter asks how technology can expand human capability without demanding attention, dependence, lock-in, or loss of judgment. It explores repair, interoperability, open systems, AI, automation, resilience, local capability, and technology that knows when to get out of the way.
 
+### 6. [Energy — Power Without Dependence](energy/index.html)
+
+The sixth chapter asks how modern civilization can keep reliable, abundant energy while reducing ecological damage, waste, fragility, and dependence. It explores grids, local resilience, renewables, nuclear power, buildings, transportation, energy access, and the value of judging energy sources by real tradeoffs instead of political identity.
+
 Long chapters are optional depth. The doctrine itself should remain readable without them.
 
 ## Where This Can Grow
 
-Future subjects may include energy, economics, education, artificial intelligence, spirituality, governance, food, architecture, transportation, family, health, ecology, and open source.
+Future subjects may include economics, education, artificial intelligence, spirituality, governance, food, architecture, transportation, family, health, ecology, and open source.
 
 We do not need a complete system before we can learn, write, test ideas, or act.
 
@@ -211,6 +217,9 @@ Among the questions still to explore:
 - How should gains from productivity be divided among wages, prices, profits, public benefits, and human time?
 - What forms of technological openness most effectively preserve agency without blocking safety, reliability, or innovation?
 - How should AI preserve human judgment when systems become increasingly capable of acting on our behalf?
+- What mix of energy generation, storage, transmission, efficiency, and local resilience works best in different places?
+- How much redundancy should energy systems preserve even when it appears economically inefficient during normal conditions?
+- How can energy transitions reduce ecological harm without making reliable power unaffordable or politically fragile?
 - How can dense cities become deeply connected to nature?
 - How do we preserve scientific rigor while allowing spiritual pluralism?
 - What should children learn in a civilization built around human flourishing?

--- a/human-scale/energy/chapter.md
+++ b/human-scale/energy/chapter.md
@@ -1,0 +1,459 @@
+# Chapter 6: Energy — Power Without Dependence
+
+**Human Scale Doctrine — Diagnosis / Field Guide / Program**
+
+> Energy should be abundant enough to support a good life, clean enough not to poison the future, resilient enough to survive failure, and distributed enough that power does not always mean dependence.
+
+Civilization runs on energy.
+
+Food systems, clean water, sanitation, refrigeration, heating and cooling, hospitals, transportation, manufacturing, communication, computing, construction, and nearly every form of modern infrastructure depend on reliable energy.
+
+The Human Scale Doctrine is not an argument for energy scarcity.
+
+A society that cannot provide dependable power will struggle to provide health, safety, comfort, education, industry, or technological freedom.
+
+But energy systems also shape the physical scale of civilization, the places people live, the resources extracted, the pollution created, the institutions that gain power, and the vulnerabilities people inherit.
+
+The question is not simply how to produce more energy.
+
+It is:
+
+**How do we build an energy system powerful enough for modern life without making human life ecologically destructive, politically fragile, or permanently dependent on systems people cannot influence?**
+
+---
+
+# Part I — Diagnosis
+
+## 1. Energy is hidden infrastructure
+
+Most people rarely think about energy when it works.
+
+A switch is flipped and the room lights up. Food stays cold. Water moves. Phones charge. Hospitals run. Servers answer. Elevators rise. Factories operate.
+
+This invisibility is a sign of successful infrastructure.
+
+It can also hide how deeply daily life depends on systems that stretch across mines, wells, power plants, transmission lines, pipelines, ports, refineries, substations, markets, software, maintenance crews, and political agreements.
+
+Human Scale asks us to make that dependence visible enough to reason about it.
+
+## 2. Fossil energy changed the scale of civilization
+
+Coal, oil, and natural gas gave industrial societies access to concentrated stores of energy that could be transported, stored, and used on demand.
+
+That energy enabled extraordinary advances.
+
+It also made it easier to build systems around long distances, high material throughput, constant transportation, disposable products, heavy mechanization, and large centralized institutions.
+
+The Human Scale critique is not that fossil fuels produced nothing good.
+
+It is that energy abundance arrived before civilization had a mature understanding of ecological limits and human needs.
+
+The result was not only pollution.
+
+It was a civilization redesigned around the assumption that enormous quantities of concentrated energy would always be available.
+
+## 3. Cheap energy can hide bad design
+
+Energy can compensate for environments that fight the human body and the local climate.
+
+A poorly designed building can be heated and cooled harder.
+
+A distant suburb can be connected by longer drives.
+
+Food can travel farther because refrigeration and transportation make it possible.
+
+Materials can be discarded because replacement is cheap enough.
+
+Efficiency therefore matters, but the deeper question is often whether the system should require so much energy in the first place.
+
+Human Scale favors **good design before brute force.**
+
+Shade before excessive cooling.
+
+Insulation before endless heating.
+
+Walkable access before unnecessary travel.
+
+Durability before constant replacement.
+
+## 4. Extraction is part of the system
+
+Every energy technology has a physical footprint.
+
+Fuels, metals, minerals, concrete, land, water, factories, transmission equipment, batteries, reactors, turbines, panels, engines, and electronic controls all come from somewhere and eventually require repair, recycling, storage, disposal, or replacement.
+
+A system should not be called clean merely because its pollution happens far away from the person using the energy.
+
+Human Scale energy thinking should consider the entire chain:
+
+- extraction
+- manufacturing
+- operation
+- transportation
+- land use
+- waste
+- maintenance
+- decommissioning
+- working conditions
+- ecological consequences
+
+No energy source is impact-free.
+
+The task is to compare impacts honestly rather than demand purity.
+
+## 5. Centralization creates capability and vulnerability
+
+Large power plants and interconnected grids can provide enormous reliability and economies of scale.
+
+They can move electricity across regions, balance demand, share generation, support heavy industry, and keep local shortages from becoming local collapse.
+
+But highly centralized systems can also create long chains of dependence.
+
+A household may have sunlight on its roof, wind nearby, or stored energy in a vehicle and still be completely powerless when one upstream system fails.
+
+Human Scale does not mean every household should go off-grid.
+
+It means that resilience can improve when **large shared systems and smaller local systems support each other.**
+
+## 6. Energy is political power
+
+Whoever controls essential energy infrastructure influences prices, land use, economic development, transportation, industry, and the basic conditions of daily life.
+
+This does not mean all energy must be publicly owned or locally owned.
+
+It means ownership and governance matter.
+
+A technically excellent energy system can still produce dependency if ordinary people have no meaningful way to understand prices, contest decisions, choose alternatives, participate in local generation, or benefit from infrastructure placed around them.
+
+## 7. Energy poverty is not human scale
+
+A romantic preference for simplicity can become cruel if it ignores what dependable energy does for human life.
+
+People need refrigeration for food and medicine, safe indoor temperatures, light, communication, water systems, transportation, cooking, and access to modern services.
+
+The goal cannot be to make energy so scarce or expensive that ordinary life becomes harder for people with the least money.
+
+The Human Scale goal is **sufficiency, abundance where it improves life, and restraint where consumption mainly compensates for wasteful design.**
+
+## 8. The transition itself has human costs
+
+Changing an energy system affects workers, households, industries, regions, public budgets, supply chains, and infrastructure built over decades.
+
+A transition that is ecologically ambitious but unreliable, unaffordable, or politically impossible can fail the people it was supposed to serve.
+
+Likewise, protecting existing systems forever because transition is difficult can lock in harms that grow over time.
+
+Human Scale requires both urgency and competence.
+
+We should change direction without pretending that complex systems can be replaced by slogans.
+
+---
+
+# Part II — Field Guide
+
+## 9. Learn where your energy comes from
+
+You do not need to become an electrical engineer.
+
+But it is useful to know the basics of the systems supporting your household and community.
+
+What powers the local grid?
+
+What uses the most energy in the home?
+
+What fails during an outage?
+
+Which systems depend on gas, electricity, fuel, or batteries?
+
+Where are the shutoffs?
+
+What needs backup first?
+
+Understanding the basics turns energy from an invisible bill into a system you can reason about.
+
+## 10. Reduce waste before reducing life
+
+The easiest energy to manage is often energy that never needed to be used.
+
+But conservation should target waste before comfort, health, or participation.
+
+Useful priorities can include:
+
+- shade and ventilation
+- insulation and weather sealing
+- efficient lighting and appliances
+- turning off genuinely unused loads
+- maintaining equipment
+- reducing unnecessary driving
+- combining trips
+- using smaller devices for smaller tasks
+- choosing durable products
+
+The goal is not discomfort as virtue.
+
+The goal is to get more human benefit from each unit of energy.
+
+## 11. Design with the climate
+
+Human settlements existed before mechanical heating and cooling at today's scale.
+
+Many traditional strategies remain useful when combined with modern materials and engineering:
+
+- orientation
+- shade
+- cross-ventilation
+- thermal mass where appropriate
+- trees and vegetation
+- daylight
+- reflective surfaces
+- insulated envelopes
+- courtyards and protected outdoor spaces
+
+Modern energy should make buildings better, not excuse buildings from understanding place.
+
+## 12. Build modest resilience
+
+A household does not need to become an isolated survival compound to become less fragile.
+
+Depending on local conditions and resources, resilience might include:
+
+- backup lighting
+- charged power banks
+- safe emergency power for essential devices
+- knowing how to keep food safe during an outage
+- backup communication
+- a plan for heat or cold
+- neighbors who know who needs medical electricity
+- rooftop or community generation where practical
+- batteries or other storage where they make sense
+
+The important principle is graceful failure.
+
+A temporary outage should not immediately turn ordinary life into chaos.
+
+## 13. Match the tool to the need
+
+Do not use industrial-scale solutions for every small problem.
+
+A bicycle may solve a short trip better than a car.
+
+A fan may solve a comfort problem before whole-building cooling.
+
+A clothesline may occasionally replace a dryer.
+
+A solar light may serve a path without trenching new infrastructure.
+
+The point is not primitive living.
+
+It is choosing the smallest adequate system when that system works well.
+
+## 14. Participate where possible
+
+Energy systems feel less abstract when people can take part in them.
+
+That might mean rooftop solar, community solar, a cooperative, a public utility meeting, a local resilience project, building retrofits, neighborhood shade, electric transportation, home energy monitoring, or simply understanding local proposals before voting on them.
+
+Not everyone needs to become an energy producer.
+
+But a society is healthier when energy is not something citizens can only buy and never understand or influence.
+
+---
+
+# Part III — Program
+
+## 15. Aim for clean, reliable, abundant energy
+
+Human Scale should reject the false choice between ecological responsibility and reliable modern life.
+
+The goal should be energy that is:
+
+- reliable
+- affordable
+- low in harmful pollution
+- increasingly low-carbon
+- resilient to disruption
+- maintainable
+- materially responsible
+- compatible with a healthy living world
+
+Different places may reach that goal with different mixes of technologies.
+
+The doctrine should not become a loyalty test for one energy source.
+
+## 16. Use a portfolio, not a purity test
+
+Solar, wind, hydroelectric power, geothermal energy, nuclear energy, storage, transmission, demand management, efficiency, and remaining fuel-based systems each have different strengths, limits, costs, land requirements, material needs, and operating characteristics.
+
+Human Scale should evaluate them by outcomes and tradeoffs rather than political identity.
+
+A technology that works well in one region may be a poor fit in another.
+
+A mature system can combine technologies instead of asking one source to solve every problem.
+
+## 17. Take nuclear energy seriously
+
+Nuclear power raises legitimate questions about cost, construction, waste, safety, governance, proliferation, maintenance, and institutional competence.
+
+It also offers characteristics that deserve serious evaluation wherever reliable low-carbon power is needed.
+
+Human Scale should neither worship nor forbid nuclear energy as an identity.
+
+It should ask the same questions applied elsewhere:
+
+Does it improve reliability?
+
+What are the full costs and risks?
+
+Can the institutions operating it be trusted and held accountable?
+
+How does it compare with realistic alternatives in that place?
+
+## 18. Take renewable energy seriously too
+
+Renewable generation can distribute production, reduce fuel dependence, and make use of ongoing natural energy flows.
+
+But renewable does not mean consequence-free.
+
+Siting, transmission, storage, manufacturing, land, habitat, minerals, recycling, intermittency, and local acceptance all matter.
+
+A Human Scale renewable buildout should try to increase clean energy while respecting communities and ecosystems rather than treating open land as empty space.
+
+## 19. Keep the grid and make it better
+
+A human-scale energy future is not necessarily millions of isolated microgrids.
+
+Large interconnected grids provide real benefits.
+
+They allow regions to share generation, balance weather, move power to where it is needed, support hospitals and industry, and use resources that cannot be produced everywhere.
+
+The grid should remain a shared backbone.
+
+But the backbone can coexist with distributed generation, local storage, microgrids for critical facilities, flexible loads, community energy, and buildings that can reduce demand during stress.
+
+**Local resilience and regional interconnection are complements, not enemies.**
+
+## 20. Let communities benefit from infrastructure
+
+Communities that host generation, transmission, extraction, storage, or industrial facilities should not be treated merely as locations on a map.
+
+Projects should consider local health, land, jobs, tax base, ownership opportunities, environmental burdens, property impacts, public participation, and long-term stewardship.
+
+The details will differ by project.
+
+The principle is simple:
+
+**People asked to carry infrastructure should have a meaningful voice in it and a fair chance to share in its benefits.**
+
+## 21. Treat buildings as energy infrastructure
+
+Energy policy often focuses on power plants while ignoring the buildings that consume the power.
+
+Building codes, retrofits, shade, insulation, passive design, efficient equipment, district systems, trees, housing location, and architecture can reduce energy demand while improving comfort.
+
+A building that stays habitable longer during an outage is also a resilience asset.
+
+## 22. Treat transportation as energy policy
+
+Transportation consumes energy partly because of vehicles and partly because of distance.
+
+A cleaner vehicle helps.
+
+So does a city where fewer trips require a vehicle at all.
+
+Human Scale transportation should combine efficient vehicles and clean fuels with land use that makes walking, cycling, transit, and shorter trips practical.
+
+The cleanest mile is useful.
+
+The unnecessary mile is better avoided.
+
+## 23. Build local energy capability without abandoning scale
+
+Communities should be able to develop some local capacity where practical:
+
+- rooftop and community generation
+- local storage
+- microgrids for critical facilities
+- neighborhood resilience hubs
+- local installers and repair workers
+- open monitoring and control systems
+- community or cooperative ownership models
+- public buildings that can provide power during emergencies
+
+This is not a demand for total energy independence.
+
+It is a way to make the larger system less brittle and give communities more practical agency.
+
+## 24. Make essential energy broadly accessible
+
+A modern society should treat a basic level of reliable household energy as foundational infrastructure.
+
+The exact policy mechanism is a political question.
+
+Options may include rate design, public assistance, efficiency upgrades, housing standards, utility reform, local generation, or other approaches.
+
+The Human Scale value is that people should not have to choose between electricity, food, safe temperature, or medicine while society wastes energy elsewhere.
+
+## 25. Price failure honestly
+
+Energy decisions often compare visible financial costs while hiding other costs in public health, pollution, ecological damage, outage risk, military vulnerability, cleanup, decommissioning, or future infrastructure.
+
+No accounting method will be perfect.
+
+But decisions improve when costs are not simply moved off the balance sheet because someone else pays them later.
+
+## 26. Preserve redundancy
+
+An energy system optimized only for average conditions may fail badly during extreme ones.
+
+Human Scale resilience may justify spare capacity, multiple transmission paths, backup generation, storage, fuel reserves, local islands, black-start capability, manual procedures, and other redundancy.
+
+Some redundancy looks inefficient when nothing is wrong.
+
+That is the point.
+
+Resilience is capacity reserved for the moment ordinary assumptions fail.
+
+## 27. A Human Scale energy test
+
+When evaluating an energy technology, utility model, building, transportation plan, grid project, or policy, ask:
+
+- Does it provide dependable energy for real human needs?
+- Is it affordable for ordinary people?
+- What pollution and ecological damage does it create across its full lifecycle?
+- What land, water, fuel, materials, and infrastructure does it require?
+- How resilient is it when weather, markets, networks, or supply chains fail?
+- Does it strengthen or weaken local agency?
+- Who owns it, who controls it, and who receives the benefits?
+- Who bears the risks and physical burdens?
+- Does it work with larger regional systems rather than assuming false independence?
+- Can it be maintained, repaired, and eventually decommissioned responsibly?
+- Does it reduce wasteful demand or simply feed it?
+- Does the system support healthier places and more human time?
+
+No energy system will score perfectly.
+
+The purpose of the test is to make the tradeoffs visible.
+
+---
+
+## The deeper idea
+
+Energy is not the enemy.
+
+Humanity learned to command extraordinary amounts of power, and much of modern civilization depends on that achievement.
+
+We should not surrender medicine, refrigeration, clean water, communication, industry, travel, computation, or the ability to make hard physical work easier.
+
+The challenge is to become wiser about what all that power is for.
+
+A humane energy system should give people enough power to live well without demanding a dead landscape, permanent pollution, fragile dependence, or endless material waste.
+
+It should combine the strengths of large systems with the resilience of smaller ones.
+
+It should make abundance compatible with stewardship.
+
+It should let a village use the grid without being helpless without it.
+
+It should let advanced civilization exist without making every community a sacrifice zone.
+
+**The goal is not less power. It is power placed back in service of life.**

--- a/human-scale/energy/index.html
+++ b/human-scale/energy/index.html
@@ -1,0 +1,274 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Energy — Power Without Dependence</title>
+  <meta name="description" content="Chapter 6 of the Human Scale Doctrine: reliable energy, resilience, local capability, grids, renewables, nuclear power, efficiency, and ecological stewardship." />
+  <meta name="theme-color" content="#07111f" />
+  <link rel="icon" href="../../favicon.ico" type="image/x-icon" />
+  <style>
+    :root {
+      color-scheme: dark;
+      --bg: #07111f;
+      --panel: #0c192a;
+      --text: #edf3fa;
+      --muted: #aab9ca;
+      --line: #243850;
+      --sky: #7bcaff;
+      --sun: #ffe18a;
+      --green: #a9ddb0;
+    }
+    * { box-sizing: border-box; }
+    html { scroll-behavior: smooth; }
+    body {
+      margin: 0;
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      color: var(--text);
+      line-height: 1.72;
+      background:
+        radial-gradient(circle at 12% 0%, rgba(255,225,138,.12), transparent 34rem),
+        radial-gradient(circle at 92% 8%, rgba(123,202,255,.09), transparent 32rem),
+        var(--bg);
+    }
+    a { color: var(--sky); }
+    .topbar {
+      width: min(100% - 2rem, 1060px);
+      margin: 0 auto;
+      padding: 1.25rem 0;
+      display: flex;
+      justify-content: space-between;
+      gap: 1rem;
+      color: var(--muted);
+      font-size: .94rem;
+    }
+    .topbar a { color: var(--muted); text-decoration: none; }
+    header {
+      width: min(100% - 2rem, 900px);
+      margin: 0 auto;
+      padding: 5.6rem 0 4.3rem;
+      text-align: center;
+    }
+    .eyebrow {
+      color: var(--sun);
+      text-transform: uppercase;
+      letter-spacing: .16em;
+      font-size: .78rem;
+      font-weight: 850;
+    }
+    h1 {
+      margin: .8rem 0 1rem;
+      font-size: clamp(2.8rem, 8vw, 5.8rem);
+      line-height: .98;
+      letter-spacing: -.05em;
+    }
+    h2 {
+      margin: 0 0 1rem;
+      font-size: clamp(1.85rem, 5vw, 2.8rem);
+      line-height: 1.08;
+      letter-spacing: -.035em;
+    }
+    h3 { margin: 0; font-size: 1.18rem; }
+    p { margin: .9rem 0; }
+    .lead {
+      max-width: 760px;
+      margin: 0 auto;
+      color: var(--muted);
+      font-size: clamp(1.1rem, 2.5vw, 1.35rem);
+    }
+    .thesis {
+      max-width: 820px;
+      margin: 2.2rem auto 0;
+      padding: 1.35rem 1.5rem;
+      border: 1px solid rgba(255,225,138,.28);
+      border-radius: 18px;
+      background: rgba(255,225,138,.05);
+      color: #fff4cf;
+      font-size: clamp(1.15rem, 3vw, 1.58rem);
+      font-weight: 750;
+    }
+    main { width: min(100% - 2rem, 900px); margin: 0 auto; padding-bottom: 6rem; }
+    section { padding: 3.2rem 0; border-top: 1px solid var(--line); }
+    .muted { color: var(--muted); }
+    .callout {
+      margin: 1.6rem 0 0;
+      padding: 1.3rem 1.4rem;
+      border-left: 4px solid var(--sun);
+      border-radius: 0 14px 14px 0;
+      background: var(--panel);
+      font-size: 1.1rem;
+    }
+    .part {
+      color: var(--green);
+      text-transform: uppercase;
+      letter-spacing: .14em;
+      font-size: .78rem;
+      font-weight: 850;
+      margin-bottom: .55rem;
+    }
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 1rem;
+      margin-top: 1.4rem;
+    }
+    .card {
+      padding: 1.25rem;
+      border: 1px solid var(--line);
+      border-radius: 16px;
+      background: linear-gradient(145deg, rgba(17,35,58,.9), rgba(8,19,34,.9));
+    }
+    .card p { color: var(--muted); margin-bottom: 0; }
+    .principle {
+      padding: 1.5rem;
+      border: 1px solid rgba(123,202,255,.26);
+      border-radius: 18px;
+      background: rgba(123,202,255,.045);
+      color: #eaf7ff;
+      font-size: 1.2rem;
+      font-weight: 700;
+    }
+    .test { display: grid; gap: .7rem; margin-top: 1.2rem; }
+    .test div {
+      padding: .95rem 1rem;
+      border: 1px solid var(--line);
+      border-radius: 12px;
+      background: rgba(255,255,255,.025);
+    }
+    .closing { text-align: center; }
+    .closing strong {
+      display: block;
+      max-width: 760px;
+      margin: 2rem auto 0;
+      color: var(--sun);
+      font-size: clamp(1.55rem, 4.5vw, 2.45rem);
+      line-height: 1.15;
+      letter-spacing: -.03em;
+    }
+    footer { border-top: 1px solid var(--line); padding: 2.5rem 1rem 3.5rem; text-align: center; color: var(--muted); }
+    footer a { text-decoration: none; }
+  </style>
+</head>
+<body>
+  <nav class="topbar" aria-label="Page navigation">
+    <a href="../index.html">← Human Scale Doctrine</a>
+    <span>Chapter 6 · Energy</span>
+  </nav>
+
+  <header>
+    <div class="eyebrow">Diagnosis · Field Guide · Program</div>
+    <h1>Energy</h1>
+    <p class="lead">Power without dependence — reliable modern energy, ecological stewardship, local resilience, strong grids, and the question of what abundance is for.</p>
+    <div class="thesis">Energy should be abundant enough to support a good life, clean enough not to poison the future, resilient enough to survive failure, and distributed enough that power does not always mean dependence.</div>
+  </header>
+
+  <main>
+    <section>
+      <h2>The starting point</h2>
+      <p>Civilization runs on energy. Clean water, refrigeration, hospitals, heating and cooling, transportation, manufacturing, communication, computing, and modern infrastructure all depend on dependable power.</p>
+      <p>The Human Scale Doctrine is not an argument for energy scarcity.</p>
+      <div class="callout">The question is <strong>how to keep the power of modern civilization while reducing ecological damage, fragility, waste, and unnecessary dependence.</strong></div>
+    </section>
+
+    <section>
+      <div class="part">Part I — Diagnosis</div>
+      <h2>Energy changed the scale of civilization</h2>
+      <div class="grid">
+        <div class="card"><h3>Hidden infrastructure</h3><p>Daily life depends on generation, fuels, grids, markets, maintenance, extraction, software, and institutions most people rarely see.</p></div>
+        <div class="card"><h3>Fossil abundance</h3><p>Concentrated fuels enabled extraordinary capability while also encouraging systems built around long distances, high throughput, and constant mechanical power.</p></div>
+        <div class="card"><h3>Bad design</h3><p>Cheap energy can compensate for poor buildings, long trips, disposable products, and environments that ignore climate and place.</p></div>
+        <div class="card"><h3>Extraction</h3><p>Every energy technology has physical inputs, land, materials, infrastructure, maintenance, and eventual waste or decommissioning.</p></div>
+      </div>
+    </section>
+
+    <section>
+      <h2>Large systems are useful — and can be fragile</h2>
+      <p>Interconnected grids and large power plants can share generation across regions, support hospitals and industry, and achieve capabilities that isolated systems cannot.</p>
+      <div class="principle">Human Scale does not mean every household goes off-grid. It means large shared systems and smaller local systems should reinforce one another.</div>
+    </section>
+
+    <section>
+      <h2>Energy scarcity is not the answer</h2>
+      <p>Reliable energy supports health, safety, food, medicine, communication, comfort, and participation in modern society.</p>
+      <div class="callout">The goal is <strong>sufficiency, abundance where it improves life, and restraint where consumption mainly compensates for wasteful design.</strong></div>
+    </section>
+
+    <section>
+      <div class="part">Part II — Field Guide</div>
+      <h2>Use energy with more agency</h2>
+      <div class="grid">
+        <div class="card"><h3>Know the system</h3><p>Understand the basics of what powers your home, what uses the most energy, and what fails first during an outage.</p></div>
+        <div class="card"><h3>Cut waste, not life</h3><p>Prioritize shade, insulation, maintenance, efficient equipment, durable goods, and unnecessary loads before sacrificing health or comfort.</p></div>
+        <div class="card"><h3>Design with climate</h3><p>Use daylight, shade, ventilation, trees, orientation, insulation, and other passive strategies alongside modern systems.</p></div>
+        <div class="card"><h3>Build modest resilience</h3><p>Backup lighting, safe emergency power, communication, temperature plans, and neighbor coordination can make outages less dangerous.</p></div>
+        <div class="card"><h3>Match scale to need</h3><p>Use the smallest adequate solution when it genuinely works instead of defaulting to the largest machine available.</p></div>
+        <div class="card"><h3>Participate</h3><p>Community energy, retrofits, local utility decisions, resilience projects, and home monitoring can make energy less abstract.</p></div>
+      </div>
+    </section>
+
+    <section>
+      <div class="part">Part III — Program</div>
+      <h2>Build a capable energy civilization</h2>
+      <div class="grid">
+        <div class="card"><h3>Clean + reliable</h3><p>Energy policy should pursue dependable, affordable power with lower pollution, lower carbon impact, and responsible material use.</p></div>
+        <div class="card"><h3>Portfolio thinking</h3><p>Solar, wind, hydro, geothermal, nuclear, storage, transmission, efficiency, and other resources should be judged by real tradeoffs, not tribal identity.</p></div>
+        <div class="card"><h3>Strong grids</h3><p>Keep regional interconnection as a backbone while adding distributed generation, storage, microgrids, and flexible demand.</p></div>
+        <div class="card"><h3>Local benefit</h3><p>Communities hosting infrastructure should have meaningful voice and a fair opportunity to share in its benefits.</p></div>
+        <div class="card"><h3>Better buildings</h3><p>Treat shade, insulation, passive design, retrofits, trees, and efficient equipment as energy infrastructure.</p></div>
+        <div class="card"><h3>Resilience</h3><p>Redundancy, backup capacity, storage, multiple pathways, and graceful failure deserve value even when they look inefficient in normal conditions.</p></div>
+      </div>
+    </section>
+
+    <section>
+      <h2>Do not turn energy sources into identities</h2>
+      <p>Nuclear energy raises real questions about cost, safety, waste, governance, construction, and institutional competence. It also has characteristics worth serious evaluation wherever reliable low-carbon power is needed.</p>
+      <p>Renewable generation can reduce fuel dependence and distribute production, while still requiring honest consideration of land, transmission, storage, materials, habitat, manufacturing, and local acceptance.</p>
+      <div class="callout">Human Scale should ask <strong>what works here, under what conditions, at what cost, with what risks?</strong> — not which technology proves membership in the right political tribe.</div>
+    </section>
+
+    <section>
+      <h2>Local resilience + regional interconnection</h2>
+      <p>Rooftop and community generation, batteries, microgrids, resilience hubs, local repair workers, and public emergency power can make communities less brittle.</p>
+      <p>Regional grids can move energy between places, balance generation and demand, and support uses that local systems cannot handle alone.</p>
+      <div class="principle">Local resilience and regional interconnection are complements, not enemies.</div>
+    </section>
+
+    <section>
+      <h2>Energy access matters</h2>
+      <p>A basic level of reliable household energy is foundational to modern life. The exact mechanism is a political question, but energy policy should not force people to choose between electricity, food, safe temperature, or medicine while large amounts of energy are wasted elsewhere.</p>
+    </section>
+
+    <section>
+      <h2>A Human Scale energy test</h2>
+      <div class="test">
+        <div>Does it provide dependable energy for real human needs?</div>
+        <div>Is it affordable for ordinary people?</div>
+        <div>What ecological and pollution costs exist across the full lifecycle?</div>
+        <div>What land, water, fuel, materials, and infrastructure does it require?</div>
+        <div>How well does it survive outages, extreme conditions, market shocks, or supply disruption?</div>
+        <div>Who owns it, who controls it, and who receives the benefits?</div>
+        <div>Who bears the physical risks and local burdens?</div>
+        <div>Does it strengthen local capability without pretending communities can isolate themselves from larger systems?</div>
+        <div>Can it be maintained, repaired, and eventually decommissioned responsibly?</div>
+        <div>Does it reduce wasteful demand or merely feed it?</div>
+        <div>Does it support healthier places and more human time?</div>
+      </div>
+      <p class="muted">No energy system is impact-free. The purpose is to make tradeoffs visible enough to choose wisely.</p>
+    </section>
+
+    <section class="closing">
+      <h2>The deeper idea</h2>
+      <p>Energy is not the enemy. Humanity learned to command extraordinary amounts of power, and much of modern civilization depends on that achievement.</p>
+      <p>We should keep medicine, refrigeration, clean water, communication, industry, transportation, computing, and machines that spare people dangerous physical labor.</p>
+      <p>The challenge is to become wiser about what all that power is for.</p>
+      <p>Abundance should become compatible with stewardship. Large systems should coexist with local capability. Communities should benefit from the infrastructure they carry.</p>
+      <strong>The goal is not less power. It is power placed back in service of life.</strong>
+    </section>
+  </main>
+
+  <footer>
+    <a href="../index.html">Human Scale Doctrine</a> · <a href="../../index.html">tmsteph home</a><br />
+    Living framework · August 2026
+  </footer>
+</body>
+</html>

--- a/human-scale/index.html
+++ b/human-scale/index.html
@@ -197,7 +197,7 @@
 <body>
   <nav class="topbar" aria-label="Page navigation">
     <a href="../index.html">← tmsteph home</a>
-    <span>Living doctrine · v0.7</span>
+    <span>Living doctrine · v0.8</span>
   </nav>
 
   <header>
@@ -260,15 +260,16 @@
 
     <section>
       <h2>What progress should mean</h2>
-      <p>Progress is more than GDP, speed, scale, convenience, or computational power. A civilization is progressing when people have healthier bodies, deeper relationships, durable community, meaningful work, time that is actually theirs, agency over the technology around them, access to nature and living land, material security, room to create, and a living world to pass on.</p>
+      <p>Progress is more than GDP, speed, scale, convenience, or computational power. A civilization is progressing when people have healthier bodies, deeper relationships, durable community, meaningful work, time that is actually theirs, agency over technology, reliable energy without permanent ecological damage or fragility, access to nature and living land, material security, room to create, and a living world to pass on.</p>
     </section>
 
     <section>
       <h2>The direction</h2>
       <p><strong>Technology:</strong> open, repairable, interoperable, resilient, agency-expanding, and quiet enough to disappear when it is not needed.</p>
+      <p><strong>Energy:</strong> clean, reliable, affordable, resilient, and capable of combining strong shared grids with meaningful local capacity.</p>
       <p><strong>Society:</strong> stronger families and communities, repeated local relationships, meaningful public space, access to living land, time for care, rest and civic life, pluralism, and power that stays understandable and accountable.</p>
       <p><strong>Inner life:</strong> room for science and reason alongside prayer, meditation, yoga, art, music, philosophy, nature, and the human search for meaning.</p>
-      <div class="callout">The goal is not maximum technology. The goal is the right technology in the right place, serving life.</div>
+      <div class="callout">The goal is not maximum technology or maximum consumption. The goal is enough capability to support life well.</div>
     </section>
 
     <section>
@@ -279,6 +280,7 @@
       <a class="chapter" href="community/index.html"><strong>Chapter 3: Community — The Human Need to Belong →</strong><span>Neighbors, repeated relationships, shared meals and work, third places, caregiving, local participation, and belonging without captivity.</span></a>
       <a class="chapter" href="work-time/index.html"><strong>Chapter 4: Work & Time — What Is a Human Life For? →</strong><span>Paid work and human contribution, predictable time, commuting, care, worker agency, automation, and the possibility that productivity should give some of our lives back.</span></a>
       <a class="chapter" href="technology/index.html"><strong>Chapter 5: Technology — Tools That Serve Life →</strong><span>Attention, repairability, interoperability, AI, automation, resilience, open systems, and tools that expand human capability without becoming the whole environment.</span></a>
+      <a class="chapter" href="energy/index.html"><strong>Chapter 6: Energy — Power Without Dependence →</strong><span>Reliable modern energy, strong grids, local resilience, renewables, nuclear power, efficiency, energy access, and abundance placed back in service of life.</span></a>
     </section>
 
     <section>
@@ -292,7 +294,7 @@
       <p>We can keep the knowledge. We can keep the science. We can keep the computers.</p>
       <p>And we can use them to build a civilization in which people once again belong to their bodies, their communities, and the Earth.</p>
       <strong>The village and the computer can coexist.</strong>
-      <p class="version">Version 0.7 · A living doctrine, expected to change as its ideas are challenged, tested, and refined.</p>
+      <p class="version">Version 0.8 · A living doctrine, expected to change as its ideas are challenged, tested, and refined.</p>
     </section>
   </main>
 


### PR DESCRIPTION
## What changed
- Added Chapter 6 of the Human Scale Doctrine: **Energy — Power Without Dependence**.
- Added Markdown source and a mobile-friendly public chapter page.
- Updated the doctrine to v0.8 and linked Chapter 6 from the main Human Scale page.
- Developed energy around reliability, affordability, ecological stewardship, resilience, grids, local capability, buildings, transportation, renewables, nuclear power, and essential energy access.
- Explicitly rejected both energy scarcity and the idea that Human Scale means every household should go off-grid.

## Why
The doctrine begins with fossil energy as a major accelerant of industrial mismatch. Chapter 6 addresses the other half of that argument: modern civilization genuinely needs abundant dependable energy, so the task is to preserve capability while reducing waste, fragility, pollution, ecological damage, and unnecessary dependence.

## Scope
The chapter keeps the simple **Diagnosis → Field Guide → Program** structure and treats energy technologies by tradeoffs and outcomes rather than political identity.