### PR TITLE
audit Technology and add Attention & Media

### DIFF
--- a/human-scale/attention-media/chapter.md
+++ b/human-scale/attention-media/chapter.md
@@ -1,0 +1,753 @@
+# Chapter 14: Attention & Media — What Gets to Enter the Mind
+
+**Human Scale Doctrine — Diagnosis / Field Guide / Program**
+
+> Attention is part of a human life. Systems that compete for it are competing for pieces of that life.
+
+Human beings have always lived inside stories, symbols, gossip, ritual, art, persuasion, propaganda, entertainment, teaching, memory, and public argument.
+
+Modern media did not invent influence.
+
+It changed:
+
+- its scale;
+- its speed;
+- its personalization;
+- its measurement;
+- its business models;
+- its persistence;
+- its capacity to optimize against human behavior.
+
+A person can now carry a globally networked persuasion environment in a pocket.
+
+That environment can provide extraordinary benefits:
+
+- education;
+- friendship;
+- news;
+- art;
+- humor;
+- political speech;
+- emergency information;
+- communities unavailable locally;
+- professional opportunity;
+- coordination;
+- access for disabled and isolated people;
+- direct publishing;
+- scientific communication;
+- creative tools.
+
+It can also create:
+
+- manipulation;
+- compulsive checking;
+- misinformation;
+- harassment;
+- surveillance;
+- outrage incentives;
+- hidden advertising;
+- distorted social comparison;
+- loss of privacy;
+- attention fragmentation;
+- concentrated agenda-setting power.
+
+Human Scale therefore asks:
+
+**What kinds of media expand human understanding and agency, and what kinds turn attention into a resource extracted from people without meaningful consent?**
+
+---
+
+# Part I — Diagnosis
+
+## 1. Attention Is Finite Even When Information Is Infinite
+
+No person can read, watch, verify, answer, learn, care about, or respond to everything available.
+
+Information abundance therefore creates a selection problem.
+
+Something must decide:
+
+- what appears first;
+- what is repeated;
+- what is hidden;
+- what interrupts;
+- what is recommended;
+- what is measured;
+- what becomes socially visible.
+
+That selection can be made by:
+
+- the individual;
+- editors;
+- friends;
+- institutions;
+- search systems;
+- recommendation algorithms;
+- advertisers;
+- political actors;
+- platform incentives;
+- AI agents.
+
+The question is not whether information is filtered.
+
+It always is.
+
+The question is:
+
+**who controls the filter, according to what objective, and can the person understand or change it?**
+
+## 2. Persuasion Is Not Automatically Manipulation
+
+Human beings persuade one another constantly.
+
+A teacher explains.
+
+A friend recommends.
+
+A candidate campaigns.
+
+A nonprofit advocates.
+
+A company advertises.
+
+A parent sets a boundary.
+
+An artist evokes emotion.
+
+A public-health agency tries to change behavior.
+
+Persuasion becomes more ethically concerning when it relies on:
+
+- deception;
+- hidden sponsorship;
+- false scarcity;
+- obstructed cancellation;
+- covert data use;
+- exploiting known vulnerabilities;
+- misleading defaults;
+- impersonation;
+- fabricated social proof;
+- making refusal unusually difficult;
+- targeting people because a sensitive condition makes them easier to influence.
+
+The FTC’s work on deceptive “dark patterns” demonstrates that interface design can cross from persuasion into consumer deception.
+
+Human Scale therefore rejects the fantasy of value-neutral communication while still drawing lines around manipulation.
+
+## 3. Engagement Is Not the Same as Value
+
+Platforms can measure:
+
+- clicks;
+- watch time;
+- comments;
+- shares;
+- reactions;
+- scrolling;
+- purchase;
+- return frequency.
+
+Those are behavioral signals.
+
+They are not complete measures of:
+
+- truth;
+- learning;
+- well-being;
+- wisdom;
+- civic understanding;
+- relationship quality;
+- long-term satisfaction.
+
+An angry person may engage intensely.
+
+A frightened person may return repeatedly.
+
+A satisfied user may finish a task and leave.
+
+Human Scale therefore treats engagement as **one metric**, not the purpose of media.
+
+## 4. “Screen Time” Is Too Crude
+
+The same device can be used to:
+
+- talk to a grandparent;
+- read a book;
+- edit music;
+- navigate a city;
+- watch short-form video;
+- learn a language;
+- work;
+- doomscroll;
+- join a support group;
+- play with friends;
+- make art;
+- receive emergency alerts.
+
+Duration matters in some contexts.
+
+So do:
+
+- content;
+- timing;
+- social context;
+- purpose;
+- interruption;
+- displacement;
+- sleep;
+- age;
+- user control;
+- platform design.
+
+Human Scale should avoid treating one hour on a device as one standardized dose.
+
+## 5. Children Deserve Stronger Protection
+
+Children and adolescents are still developing judgment, impulse control, identity, social understanding, and self-regulation.
+
+The U.S. Surgeon General’s social-media advisory concluded that current evidence does not allow social media to be considered sufficiently safe for children and adolescents and called for stronger research, platform responsibility, family support, and age-appropriate safeguards.
+
+This does not mean every form of digital social life is harmful.
+
+It means uncertainty should not automatically be resolved in favor of maximum commercial exposure.
+
+Human Scale applies a precautionary principle more strongly when:
+
+- the user is a child;
+- the system is highly persuasive;
+- the data is sensitive;
+- exit is difficult;
+- developmental effects are uncertain;
+- incentives reward engagement regardless of downstream outcome.
+
+Official source:
+- U.S. Surgeon General, *Social Media and Youth Mental Health*: https://www.hhs.gov/surgeongeneral/priorities/youth-mental-health/social-media/index.html
+
+## 6. News Is Both Information and Environment
+
+News helps people understand events beyond direct experience.
+
+A functioning society requires ways to discover:
+
+- what happened;
+- who made a decision;
+- what institutions are doing;
+- what risks exist;
+- what evidence supports competing claims.
+
+But news can also become a continuous threat stream far beyond any individual’s capacity to act.
+
+Human Scale asks two questions:
+
+1. **What information do I need to understand and act?**
+2. **What information am I consuming because a system benefits from keeping me activated?**
+
+This is not an argument for ignorance.
+
+It is an argument for proportion between information, agency, and attention.
+
+## 7. Algorithms Are Editors With Different Governance
+
+Recommendation systems rank information.
+
+That is an editorial function even when no human editor chooses each item individually.
+
+Algorithms can improve relevance and discovery.
+
+They can also optimize for objectives users do not fully understand.
+
+Human Scale therefore prefers transparency about:
+
+- why something is recommended;
+- which signals matter;
+- whether paid placement is involved;
+- how personalization can be reduced or reset;
+- how to access chronological, subscribed, search-based, or other non-recommended modes where practical.
+
+Not every algorithm needs to publish proprietary code.
+
+But consequential ranking should be legible enough for users and regulators to understand what kind of system they are interacting with.
+
+## 8. Advertising Can Fund Useful Things
+
+Advertising has funded:
+
+- newspapers;
+- radio;
+- television;
+- search;
+- maps;
+- social platforms;
+- free software;
+- cultural production;
+- local media;
+- public-interest content.
+
+Advertising is not automatically corrupt.
+
+But an advertising model can create pressure to maximize:
+
+- attention;
+- profiling;
+- emotional activation;
+- conversion;
+- repeated consumption.
+
+The question is not “ads or no ads.”
+
+It is:
+
+> **what does the advertising system need to know about people, what behavior does it reward, how clearly is persuasion labeled, and how easy is refusal?**
+
+## 9. Political Persuasion Needs Higher Standards
+
+Political communication affects rights, institutions, war, taxation, law, public goods, and the distribution of power.
+
+Human Scale therefore rejects:
+
+- fabricated grassroots support;
+- impersonation;
+- hidden sponsorship;
+- deliberately false claims;
+- harassment campaigns;
+- doxxing;
+- covert manipulation of people based on sensitive personal traits;
+- repeated unwanted contact.
+
+A pluralistic political culture should still allow:
+
+- argument;
+- organizing;
+- campaigning;
+- advocacy;
+- satire;
+- protest;
+- persuasion;
+- criticism;
+- strong disagreement.
+
+The line is not “emotion versus reason.”
+
+Humans are emotional beings.
+
+The line is whether persuasion preserves enough truthfulness, identity transparency, consent, and freedom of response for civic agency to remain meaningful.
+
+## 10. AI Changes the Cost of Media Production
+
+Generative AI can lower the cost of:
+
+- writing;
+- translation;
+- design;
+- video;
+- audio;
+- tutoring;
+- research assistance;
+- personalization;
+- accessibility.
+
+It can also lower the cost of:
+
+- spam;
+- impersonation;
+- synthetic reviews;
+- propaganda;
+- harassment;
+- mass persuasion;
+- low-quality content;
+- fabricated evidence.
+
+Human Scale therefore values provenance and accountability.
+
+When content materially depends on synthetic generation, people should have enough context to understand what kind of artifact they are consuming when that distinction matters.
+
+The objective is not to stigmatize AI assistance.
+
+It is to prevent cheap generation from destroying the signals people use to decide what deserves trust.
+
+## 11. Free Speech and Attention Are Different Questions
+
+A person can have the right to speak without having a right to algorithmic amplification, guaranteed distribution, or another person’s attention.
+
+Platforms and institutions inevitably make moderation, ranking, and distribution choices.
+
+Human Scale therefore separates:
+
+- legal speech rights;
+- platform rules;
+- editorial selection;
+- recommendation;
+- paid amplification;
+- personal filtering.
+
+These categories involve different institutions and different rights.
+
+Conflating them makes public argument harder.
+
+## 12. Media Literacy Cannot Carry the Whole Burden
+
+People should learn to:
+
+- check sources;
+- distinguish evidence from assertion;
+- recognize advertising;
+- understand recommendation systems;
+- notice emotional manipulation;
+- verify before sharing;
+- recognize uncertainty;
+- understand basic statistics;
+- identify conflicts of interest.
+
+But a society should not respond to deceptive systems only by telling every citizen to become infinitely skeptical.
+
+Good design, regulation, journalism, platform governance, education, and personal skill all have roles.
+
+---
+
+# Part II — Field Guide
+
+## 13. Choose Information Intentionally
+
+Build at least some information pathways based on direct choice rather than recommendation alone.
+
+Examples:
+
+- bookmarks;
+- RSS;
+- direct subscriptions;
+- saved searches;
+- library sources;
+- trusted newsletters;
+- primary documents;
+- chronological feeds where available.
+
+Recommendation systems can remain useful.
+
+The goal is not purity.
+
+It is avoiding complete dependence on a ranking system whose objective you do not control.
+
+## 14. Separate “Need to Know” From “Can Keep Watching”
+
+Before consuming more news or commentary, ask:
+
+- What decision will this information change?
+- Is this genuinely new?
+- Is there a primary source?
+- Am I learning or merely refreshing?
+- Can I act?
+- Would checking later produce the same practical outcome?
+
+## 15. Remove Some Nonessential Interruptions
+
+Try the Human Scale Lab’s Quiet Technology experiment.
+
+Keep useful services while reducing:
+
+- nonessential notifications;
+- badges;
+- infinite-feed shortcuts;
+- automated promotional alerts;
+- unnecessary email pushes.
+
+Measure what becomes worse as well as what improves.
+
+## 16. Protect Sleep From the Information Environment
+
+Information has no natural bedtime.
+
+Human beings do.
+
+Create practical boundaries that fit the household and life stage:
+
+- charge devices away from the bed where useful;
+- use do-not-disturb;
+- avoid work notifications during protected sleep windows where possible;
+- do not assume every message requires immediate response.
+
+This is not moral purity.
+
+It is environmental design.
+
+## 17. Build Direct Relationships With People You Value
+
+If a creator, community, publication, or organization matters to you, prefer at least one direct connection where possible:
+
+- email;
+- RSS;
+- direct messaging;
+- website;
+- phone;
+- in-person contact;
+- portable social protocol.
+
+Do not require an algorithm to repeatedly rediscover relationships you already chose.
+
+## 18. Slow Down High-Stakes Sharing
+
+Before sharing claims about:
+
+- health;
+- elections;
+- war;
+- emergencies;
+- accusations;
+- public figures;
+- financial decisions;
+
+look for stronger sourcing.
+
+The cost of waiting a few minutes is often smaller than the cost of distributing a false claim.
+
+---
+
+# Part III — Program
+
+## 19. Require Clear Advertising Identity
+
+People should be able to recognize when communication is paid persuasion.
+
+Advertising systems should make sponsorship legible rather than hiding it inside ordinary social proof.
+
+Influence does not need to be shameful.
+
+It needs to be identifiable.
+
+## 20. Restrict Deceptive Design
+
+Consumer protection should continue treating interface deception as a real form of commercial conduct.
+
+Examples worth scrutiny include:
+
+- hidden recurring charges;
+- false countdowns;
+- obstructed cancellation;
+- disguised ads;
+- preselected consent that hides material consequences;
+- confusing privacy choices;
+- visual designs that make refusal disproportionately difficult.
+
+FTC dark-pattern guidance provides one current official foundation.
+
+Source:
+https://www.ftc.gov/reports/bringing-dark-patterns-light
+
+## 21. Offer Meaningful Feed Controls
+
+Where practical, platforms should let users understand or choose among modes such as:
+
+- recommendation;
+- chronological/subscribed;
+- search;
+- topic filters;
+- reduced personalization;
+- resettable personalization.
+
+This does not require every service to have the same interface.
+
+It creates a design norm: **the ranking system should not be the only doorway to the user’s own social and information world.**
+
+## 22. Create Stronger Default Protections for Children
+
+Potential measures to evaluate include:
+
+- age-appropriate design;
+- default privacy;
+- limits on sensitive profiling;
+- reduced persuasive notifications;
+- time-of-day protections;
+- transparent recommendation systems;
+- easier family controls that respect growing adolescent autonomy;
+- independent research access with privacy safeguards.
+
+Policies should be evaluated for effectiveness, privacy, circumvention, speech impacts, and unintended consequences.
+
+## 23. Protect Direct Publishing and Open Knowledge
+
+A healthy information environment needs more than a few large feeds.
+
+Human Scale values:
+
+- websites;
+- RSS;
+- email;
+- libraries;
+- public archives;
+- open standards;
+- portable identity where practical;
+- public-interest media;
+- independent publishing;
+- interoperable social protocols.
+
+The goal is not to abolish platforms.
+
+It is to preserve routes around them.
+
+## 24. Make Provenance Easier in an AI Media World
+
+Useful tools can include:
+
+- content credentials;
+- cryptographic provenance where practical;
+- clear labeling of material synthetic alteration in high-stakes contexts;
+- verifiable original documents;
+- source chains;
+- public archives;
+- authenticated institutional communications.
+
+No provenance system will solve deception by itself.
+
+But cheap synthetic media increases the value of trustworthy origin signals.
+
+## 25. Fund Journalism Without Pretending One Model Is Neutral
+
+Possible models include:
+
+- subscriptions;
+- advertising;
+- philanthropy;
+- nonprofit ownership;
+- public media;
+- membership;
+- events;
+- bundles;
+- local sponsorship;
+- combinations.
+
+Every model creates incentives.
+
+Human Scale should ask:
+
+- Who pays?
+- What does the publisher optimize for?
+- What editorial independence exists?
+- Who can access the information?
+- What happens to local reporting?
+- Can the funding source be identified?
+
+## 26. Political Advertising Should Preserve Civic Agency
+
+A Human Scale political campaign or advocacy project should:
+
+- identify itself;
+- avoid fabricated grassroots support;
+- avoid impersonation;
+- avoid harassment and doxxing;
+- avoid covert targeting based on sensitive vulnerabilities;
+- make unsubscribe/refusal real;
+- correct material factual errors when discovered;
+- distinguish evidence from values;
+- invite scrutiny of consequential claims.
+
+Human Scale should apply these standards to its own promotion.
+
+## 27. Measure More Than Engagement
+
+Media and technology teams should experiment with outcome metrics such as:
+
+- task completion;
+- informed satisfaction;
+- trust calibration;
+- learning;
+- return without compulsion;
+- successful exit;
+- time saved;
+- error correction;
+- relationship quality;
+- user-reported control;
+- downstream harm.
+
+No single metric will replace judgment.
+
+The point is to stop pretending attention captured is equivalent to value created.
+
+## 28. A Human Scale Test for Attention & Media
+
+1. What is the user trying to do?
+2. What is the system trying to optimize?
+3. Is paid persuasion clearly identified?
+4. Are material choices reversible?
+5. Can the person reach chosen information without an algorithmic feed?
+6. What data is used to personalize persuasion?
+7. Are sensitive vulnerabilities being exploited?
+8. Is refusal easy enough to be meaningful?
+9. Does the system create unnecessary interruption?
+10. Are children given stronger protections?
+11. Can important claims be traced to sources?
+12. Does AI generation weaken provenance or accountability?
+13. Is there a route to correction or appeal?
+14. Are speech, ranking, recommendation, and paid amplification being distinguished?
+15. What would count as value besides engagement?
+16. What evidence would make us change the design?
+
+---
+
+# Evidence Notes
+
+**Dark patterns — official consumer-protection evidence.** The U.S. Federal Trade Commission has documented design practices that can deceive or manipulate consumers into purchases, subscriptions, privacy choices, or data sharing.
+
+Source:
+https://www.ftc.gov/reports/bringing-dark-patterns-light
+
+**Youth social media — official U.S. health advisory.** The U.S. Surgeon General’s advisory states that evidence is not sufficient to conclude social media is adequately safe for children and adolescents and calls for research, safety standards, family tools, and platform accountability.
+
+Source:
+https://www.hhs.gov/surgeongeneral/priorities/youth-mental-health/social-media/index.html
+
+**AI risk and human oversight — official technical framework.** NIST’s AI Risk Management Framework treats AI risk as a socio-technical governance problem involving context, measurement, transparency, human-AI interaction, monitoring, and accountability.
+
+Source:
+https://www.nist.gov/itl/ai-risk-management-framework
+
+The broader claims in this chapter about civic culture, advertising ethics, feed choice, direct publishing, and attention are mixtures of evidence, design principles, and explicit Human Scale values.
+
+---
+
+# Human Scale Advertising Standard
+
+Because Human Scale itself needs to advertise, it should be held to the same standard.
+
+Human Scale promotion should:
+
+1. identify Thomas / Human Scale as the source;
+2. avoid fake accounts and fake grassroots support;
+3. avoid repeated unwanted outreach;
+4. avoid fear-based targeting of people because of sensitive traits;
+5. not use deceptive countdowns or false scarcity;
+6. correct factual errors;
+7. link evidence when making empirical claims;
+8. distinguish “we believe” from “research shows”;
+9. promote useful tools or results rather than only demand attention;
+10. make leaving easy.
+
+The first advertising rule is:
+
+> **Every advertisement should leave the audience with something useful even if they never become a Human Scale supporter.**
+
+---
+
+# The Direction
+
+The future will contain more media, more AI, more simulation, more personalization, and more information than any individual can absorb.
+
+The solution is not to demand that human attention become infinite.
+
+It is to build systems that respect selection, boundaries, provenance, direct choice, and the right not to be continuously optimized against.
+
+We should keep free expression.
+
+Keep art.
+
+Keep humor.
+
+Keep argument.
+
+Keep advertising where it funds useful things.
+
+Keep algorithms where they help people discover what matters.
+
+Keep AI where it expands creation and understanding.
+
+And build stronger norms and institutions around deception, surveillance, manipulation, child protection, provenance, and the ownership of attention.
+
+**A humane information system does not win by capturing the most attention. It wins by helping people use their attention for lives they actually value.**

--- a/human-scale/attention-media/index.html
+++ b/human-scale/attention-media/index.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Chapter 14: Attention & Media — What Gets to Enter the Mind</title>
+  <meta name="description" content="Human Scale Chapter 14: attention, media, algorithms, advertising, dark patterns, youth, news, AI-generated media, political persuasion, provenance, and humane information systems." />
+  <meta name="theme-color" content="#07111f" />
+  <link rel="canonical" href="https://tmsteph.com/human-scale/attention-media/" />
+  <meta property="og:title" content="Attention & Media — What Gets to Enter the Mind" />
+  <meta property="og:description" content="Attention is part of a human life. Systems that compete for it are competing for pieces of that life." />
+  <meta property="og:url" content="https://tmsteph.com/human-scale/attention-media/" />
+  <meta property="og:type" content="article" />
+  <meta name="twitter:card" content="summary" />
+  <link rel="icon" href="../../favicon.ico" type="image/x-icon" />
+  <script defer src="/_vercel/analytics/script.js"></script>
+  <style>
+    :root{color-scheme:dark;--bg:#07111f;--panel:#0c192a;--text:#edf3fa;--muted:#aab9ca;--line:#243850;--sky:#7bcaff;--green:#a9ddb0;--sun:#ffe18a;--rose:#ffb8be}*{box-sizing:border-box}html{scroll-behavior:smooth}body{margin:0;font-family:Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;color:var(--text);line-height:1.72;background:radial-gradient(circle at 10% 0%,rgba(123,202,255,.11),transparent 34rem),radial-gradient(circle at 92% 8%,rgba(255,225,138,.055),transparent 31rem),var(--bg)}a{color:var(--sky)}.topbar{width:min(100% - 2rem,1040px);margin:0 auto;padding:1.25rem 0;display:flex;justify-content:space-between;gap:1rem;color:var(--muted);font-size:.92rem}.topbar a{color:var(--muted);text-decoration:none}header{width:min(100% - 2rem,900px);margin:0 auto;padding:5.4rem 0 4.1rem;text-align:center}.eyebrow{color:var(--green);font-size:.78rem;font-weight:850;letter-spacing:.15em;text-transform:uppercase}h1{margin:.75rem 0 1rem;font-size:clamp(2.8rem,8vw,5.4rem);line-height:.98;letter-spacing:-.05em}h2{margin:0 0 1rem;font-size:clamp(1.8rem,5vw,2.75rem);line-height:1.08;letter-spacing:-.035em}h3{margin:0 0 .4rem;font-size:1.16rem}.lead{max-width:790px;margin:0 auto;color:var(--muted);font-size:clamp(1.08rem,2.5vw,1.32rem)}.thesis{max-width:840px;margin:2.2rem auto 0;padding:1.35rem 1.5rem;border:1px solid rgba(255,225,138,.28);border-radius:18px;background:rgba(255,225,138,.045);color:#fff4cf;font-size:clamp(1.16rem,3vw,1.55rem);font-weight:750}main{width:min(100% - 2rem,900px);margin:0 auto;padding-bottom:6rem}section{padding:3.1rem 0;border-top:1px solid var(--line)}p{margin:.9rem 0}.muted{color:var(--muted)}.callout{margin:1.5rem 0;padding:1.25rem 1.35rem;border-left:4px solid var(--green);border-radius:0 14px 14px 0;background:var(--panel);font-size:1.08rem}.grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(250px,1fr));gap:1rem;margin-top:1.2rem}.card{padding:1.15rem;border:1px solid var(--line);border-radius:15px;background:linear-gradient(145deg,rgba(16,33,55,.9),rgba(8,19,34,.9))}.card p{color:var(--muted);margin:.45rem 0 0}.list{display:grid;gap:.7rem;margin-top:1.1rem}.item{padding:1rem 1.05rem;border:1px solid var(--line);border-radius:13px;background:rgba(255,255,255,.025)}.evidence{padding:1rem;margin-top:.8rem;border:1px solid rgba(123,202,255,.25);border-radius:14px;background:rgba(123,202,255,.04)}.evidence strong{color:#dff0ff}.evidence p{color:var(--muted);font-size:.94rem}.standard{padding:1rem 1.1rem;border:1px solid rgba(255,184,190,.28);border-radius:14px;background:rgba(255,184,190,.045);color:#ffe8ea}.closing{text-align:center}.closing strong{display:block;max-width:820px;margin:1.7rem auto 0;color:var(--sun);font-size:clamp(1.55rem,4.7vw,2.4rem);line-height:1.15}.navcards{display:grid;grid-template-columns:1fr 1fr;gap:1rem;margin-top:1.3rem}.navcard{padding:1rem;border:1px solid var(--line);border-radius:14px;background:var(--panel);color:var(--text);text-decoration:none}.navcard span{display:block;color:var(--muted);font-size:.9rem;margin-top:.25rem}footer{border-top:1px solid var(--line);padding:2.5rem 1rem 3.5rem;text-align:center;color:var(--muted)}footer a{text-decoration:none}@media(max-width:650px){.navcards{grid-template-columns:1fr}header{padding-top:4rem}}
+  </style>
+</head>
+<body>
+  <nav class="topbar"><a href="../index.html">← Human Scale Doctrine</a><span>Chapter 14</span></nav>
+  <header><div class="eyebrow">Attention & media</div><h1>What Gets to Enter the Mind</h1><p class="lead">Modern media did not invent persuasion. It changed its scale, speed, personalization, measurement, and ability to optimize against human behavior.</p><div class="thesis">Attention is part of a human life. Systems that compete for it are competing for pieces of that life.</div></header>
+  <main>
+    <section><h2>Attention is finite</h2><p>No person can read, watch, verify, answer, learn, care about, or respond to everything available. Information abundance therefore creates a filtering problem.</p><div class="callout"><strong>The question is not whether information is filtered.</strong> It always is. The question is who controls the filter, according to what objective, and whether the person can understand or change it.</div></section>
+
+    <section><h2>Diagnosis</h2><div class="grid">
+      <article class="card"><h3>Persuasion ≠ manipulation</h3><p>Teaching, recommendation, advocacy, art and advertising all persuade. Deception, hidden sponsorship, fake scarcity, fabricated social proof, obstructed cancellation and exploitative targeting cross different ethical lines.</p></article>
+      <article class="card"><h3>Engagement ≠ value</h3><p>Clicks, watch time, comments and return frequency measure behavior. They do not directly measure truth, learning, wisdom, relationship quality or long-term satisfaction.</p></article>
+      <article class="card"><h3>“Screen time” is too crude</h3><p>Video calling family, editing music, reading research, gaming with friends, doomscrolling and navigating transit are not one standardized exposure.</p></article>
+      <article class="card"><h3>Children deserve stronger protection</h3><p>Development, uncertainty, persuasive systems and sensitive data justify greater caution than “let the market optimize engagement and see what happens.”</p></article>
+      <article class="card"><h3>News is information and environment</h3><p>People need public information, but continuous exposure can become a threat stream far beyond one person’s capacity to act.</p></article>
+      <article class="card"><h3>Algorithms are editors with different governance</h3><p>Ranking systems choose what becomes visible. Users should have meaningful context and alternatives where practical.</p></article>
+      <article class="card"><h3>Advertising can fund useful things</h3><p>The important questions are what data persuasion requires, what behavior the business model rewards, whether sponsorship is visible, and whether refusal is real.</p></article>
+      <article class="card"><h3>Political persuasion needs higher standards</h3><p>Argument and campaigning are legitimate. Fabricated grassroots support, impersonation, hidden sponsorship, doxxing, harassment and covert vulnerability targeting are not.</p></article>
+      <article class="card"><h3>AI lowers media-production cost</h3><p>That expands creation and accessibility while also making spam, impersonation, synthetic reviews, propaganda and mass persuasion cheaper.</p></article>
+      <article class="card"><h3>Speech ≠ amplification</h3><p>Legal speech rights, platform rules, editorial selection, recommendation, paid amplification and personal filtering are different categories.</p></article>
+      <article class="card"><h3>Media literacy cannot carry everything</h3><p>People should learn source checking and statistics, but deceptive systems cannot be excused simply by demanding infinitely skeptical users.</p></article>
+    </div></section>
+
+    <section><h2>Field Guide</h2><div class="list">
+      <div class="item"><strong>Choose some information directly.</strong> Bookmarks, RSS, newsletters, library sources, saved searches, primary documents and chronological/subscribed modes can reduce complete dependence on recommendation feeds.</div>
+      <div class="item"><strong>Separate “need to know” from “can keep watching.”</strong> Ask what decision the next refresh will actually change.</div>
+      <div class="item"><strong>Remove some nonessential interruptions.</strong> Keep useful services while reducing notifications, badges and promotional alerts; measure what becomes worse as well as better.</div>
+      <div class="item"><strong>Protect sleep from an information environment that never sleeps.</strong> Do-not-disturb, device placement and work-notification boundaries are environmental design, not moral purity.</div>
+      <div class="item"><strong>Build direct relationships with people and publications you value.</strong> Do not require an algorithm to repeatedly rediscover choices you already made.</div>
+      <div class="item"><strong>Slow down high-stakes sharing.</strong> Health, elections, war, emergencies, accusations and financial claims deserve stronger sourcing before redistribution.</div>
+    </div></section>
+
+    <section><h2>Program</h2><div class="grid">
+      <article class="card"><h3>Clear advertising identity</h3><p>Paid persuasion should be recognizable. Sponsorship should not masquerade as ordinary social proof.</p></article>
+      <article class="card"><h3>Restrict deceptive design</h3><p>False countdowns, hidden recurring charges, disguised ads, obstructed cancellation and materially misleading consent flows belong inside consumer-protection policy.</p></article>
+      <article class="card"><h3>Meaningful feed controls</h3><p>Recommendation should not be the only doorway. Chronological/subscribed, search, reduced-personalization or reset options can preserve direct choice where practical.</p></article>
+      <article class="card"><h3>Stronger defaults for children</h3><p>Test age-appropriate privacy, reduced profiling, notification limits, recommendation transparency and research access while measuring privacy and speech tradeoffs.</p></article>
+      <article class="card"><h3>Direct publishing & open knowledge</h3><p>Websites, RSS, email, libraries, archives, open standards and interoperable protocols preserve routes around a few dominant feeds.</p></article>
+      <article class="card"><h3>Provenance in an AI media world</h3><p>Content credentials, source chains, authenticated institutional communication and verifiable originals can strengthen trust signals in high-stakes contexts.</p></article>
+      <article class="card"><h3>Plural journalism funding</h3><p>Advertising, subscriptions, membership, philanthropy, public media, nonprofit ownership and events all create incentives; compare them openly.</p></article>
+      <article class="card"><h3>Political ads preserve civic agency</h3><p>Identify the source, avoid fabricated support and covert vulnerability targeting, correct material errors, and make refusal/unsubscribe real.</p></article>
+      <article class="card"><h3>Measure more than engagement</h3><p>Task completion, learning, trust calibration, time saved, successful exit, informed satisfaction and downstream harm can matter alongside clicks.</p></article>
+    </div></section>
+
+    <section><h2>Evidence notes</h2>
+      <div class="evidence"><strong>Deceptive design</strong><p>The U.S. Federal Trade Commission has documented “dark pattern” designs that can trick or manipulate consumers into purchases, subscriptions, privacy choices or data sharing. <a href="https://www.ftc.gov/reports/bringing-dark-patterns-light" rel="noopener">FTC ↗</a></p></div>
+      <div class="evidence"><strong>Youth social media</strong><p>The U.S. Surgeon General’s advisory concluded current evidence is insufficient to conclude social media is adequately safe for children and adolescents and called for stronger research, safeguards, family tools and platform responsibility. <a href="https://www.hhs.gov/surgeongeneral/priorities/youth-mental-health/social-media/index.html" rel="noopener">HHS ↗</a></p></div>
+      <div class="evidence"><strong>AI risk and oversight</strong><p>NIST’s AI Risk Management Framework treats risk as socio-technical and emphasizes governance, measurement, human-AI configuration, monitoring and accountability rather than treating “human in the loop” as a magic phrase. <a href="https://www.nist.gov/itl/ai-risk-management-framework" rel="noopener">NIST ↗</a></p></div>
+    </section>
+
+    <section><h2>Human Scale’s own advertising standard</h2><div class="standard"><strong>Human Scale has to obey the rule it proposes for everyone else.</strong></div><div class="list">
+      <div class="item">Identify Thomas / Human Scale as the source.</div><div class="item">No fake accounts or fabricated grassroots support.</div><div class="item">No repeated unwanted outreach after silence.</div><div class="item">No fear-based targeting using sensitive vulnerabilities.</div><div class="item">No deceptive scarcity or countdowns.</div><div class="item">Correct material factual errors.</div><div class="item">Link evidence when making empirical claims.</div><div class="item">Distinguish “we believe” from “research shows.”</div><div class="item">Promote useful tools, results, maps, receipts or experiments—not only demands for attention.</div><div class="item">Make leaving easy.</div>
+    </div><div class="callout"><strong>Every advertisement should leave the audience with something useful even if they never become a Human Scale supporter.</strong></div></section>
+
+    <section><h2>A Human Scale test for attention & media</h2><div class="list">
+      <div class="item">What is the user trying to do?</div><div class="item">What is the system trying to optimize?</div><div class="item">Is paid persuasion clearly identified?</div><div class="item">Are material choices reversible?</div><div class="item">Can the person reach chosen information without an algorithmic feed?</div><div class="item">What data is used to personalize persuasion?</div><div class="item">Are sensitive vulnerabilities being exploited?</div><div class="item">Is refusal easy enough to be meaningful?</div><div class="item">Does the system create unnecessary interruption?</div><div class="item">Are children given stronger protections?</div><div class="item">Can important claims be traced to sources?</div><div class="item">Does AI generation weaken provenance or accountability?</div><div class="item">Is there a route to correction or appeal?</div><div class="item">Are speech, ranking, recommendation and paid amplification being distinguished?</div><div class="item">What would count as value besides engagement?</div><div class="item">What evidence would make us change the design?</div>
+    </div></section>
+
+    <section class="closing"><h2>The direction</h2><p>The future will contain more media, AI, simulation, personalization and information than any individual can absorb. The answer is not to demand infinite human attention.</p><strong>A humane information system does not win by capturing the most attention. It wins by helping people use their attention for lives they actually value.</strong><div class="navcards"><a class="navcard" href="../evidence/technology/index.html">Evidence Audit 05 →<span>Technology under pressure</span></a><a class="navcard" href="../san-diego/index.html">San Diego pilots →<span>Promotion through useful local work</span></a></div></section>
+  </main>
+  <footer><a href="../lab/index.html">Lab</a> · <a href="../contribute/index.html">Contribute</a> · <a href="../share/index.html">Share</a> · <a href="../index.html">Doctrine</a></footer>
+</body>
+</html>

--- a/human-scale/evidence/technology/audit.md
+++ b/human-scale/evidence/technology/audit.md
@@ -1,0 +1,403 @@
+# Evidence Audit 05: Technology
+
+**Human Scale Evidence Atlas — August 2026**
+
+> “Technology should serve human life” is a value. The hard part is deciding what evidence tells us whether a particular technology actually does.
+
+This audit puts Chapter 5 — *Technology: Tools That Serve Life* — under pressure.
+
+The chapter currently contains claims about:
+
+- attention;
+- interoperability;
+- repairability;
+- data portability;
+- open systems;
+- offline resilience;
+- technological exit;
+- automation;
+- AI;
+- skill retention;
+- persuasive design;
+- quiet interfaces;
+- local control.
+
+Many are design values rather than medical or scientific facts.
+
+That is not a weakness.
+
+It becomes a weakness only when values are presented as though the evidence mechanically selected them.
+
+---
+
+# Summary Judgment
+
+**Keep agency, exit, interoperability, repairability, and calm technology as Human Scale values. Become more precise about what is empirically demonstrated and where tradeoffs justify closed, centralized, automated, or attention-demanding systems.**
+
+The strongest foundations are:
+
+1. Interface design can influence behavior.
+2. Deceptive or manipulative interface patterns are real enough to be a regulatory and consumer-protection concern.
+3. Interruptions and notifications can impose measurable attention or task-switching costs in specific contexts.
+4. Security, privacy, safety, reliability, and coordination can sometimes justify constraints on openness or user control.
+5. Human oversight in AI is not automatically effective merely because a human remains “in the loop.” Oversight has to be designed around actual human factors.
+
+The weaker or normative claims are:
+
+- open source is always more humane;
+- local computation is always better than cloud services;
+- user repairability should override every safety, security, or certification concern;
+- quieter interfaces are always preferable;
+- automation necessarily deskills people;
+- more user choice always produces more agency;
+- decentralization automatically reduces concentration of power.
+
+---
+
+# Claim Register
+
+## Claim 1 — Interface design can steer behavior
+
+**Grade: Strong general principle**
+
+Choice architecture is not neutral.
+
+Defaults, button hierarchy, friction, timing, salience, notifications, recommendation systems, subscriptions, confirmation flows, and repeated prompts can affect behavior.
+
+The U.S. Federal Trade Commission has documented “dark patterns” and deceptive design practices that can trick or manipulate consumers into purchases, data sharing, subscriptions, or other actions.
+
+Official source:
+- FTC, *Bringing Dark Patterns to Light*: https://www.ftc.gov/reports/bringing-dark-patterns-light
+
+**Doctrine implication:** Human Scale is justified in treating interface design as an agency question, not merely aesthetics.
+
+## Claim 2 — Attention costs should be measured, not moralized
+
+**Grade: Strong mechanism in specific task contexts; broad life claims are harder**
+
+Interruptions and task switching can produce measurable performance costs.
+
+Notifications can capture attention even when a person does not act on them.
+
+But “screen time” is not one exposure.
+
+An hour spent in:
+
+- video calling family;
+- writing software;
+- doomscrolling;
+- reading a paper;
+- navigating transit;
+- playing a cooperative game;
+- watching a film;
+- responding to work messages
+
+should not be treated as one psychological category.
+
+**Doctrine implication:** Replace generic anti-screen language with mechanism-specific questions:
+
+- What is interrupting?
+- What is being substituted?
+- Is the interaction chosen?
+- Can it be stopped?
+- Does it support the person’s goal?
+- What happens to sleep, task completion, mood, relationships, or performance?
+
+## Claim 3 — “Quiet technology” is a design value with testable outcomes
+
+**Grade: Value + testable design hypothesis**
+
+Human Scale prefers technology that accomplishes the task without continually demanding attention.
+
+That preference can be tested through:
+
+- task completion;
+- interruptions;
+- errors;
+- time spent;
+- missed important events;
+- cognitive load;
+- user satisfaction;
+- compulsive checking;
+- retention of useful function.
+
+A quiet interface that hides urgent information can be worse.
+
+A high-attention interface can be appropriate in an emergency, performance, game, training exercise, or live event.
+
+**Doctrine implication:** The principle should be **attention proportional to the task**, not “less attention is always better.”
+
+## Claim 4 — Open systems can protect exit and portability
+
+**Grade: Strong as an architectural mechanism; benefits depend on implementation**
+
+Open standards, exportable data, documented formats, interoperable protocols, and substitutable components can reduce switching costs and dependency.
+
+That is a structural mechanism, not merely a cultural preference.
+
+But openness can interact with:
+
+- security;
+- privacy;
+- intellectual property;
+- safety certification;
+- abuse prevention;
+- usability;
+- maintenance;
+- fragmented user experience.
+
+**Doctrine implication:** Human Scale should prefer **credible exit** rather than treat any single licensing model as a universal proxy for agency.
+
+## Claim 5 — Open source is not identical to user freedom
+
+**Grade: Corrective principle**
+
+Software can be open source and still be:
+
+- unusable;
+- insecurely configured;
+- difficult to maintain;
+- dependent on centralized services;
+- inaccessible;
+- abandoned;
+- practically impossible for an ordinary user to modify.
+
+Proprietary systems can sometimes provide:
+
+- strong accessibility;
+- reliable maintenance;
+- security updates;
+- low-friction support;
+- durable service.
+
+Human Scale can continue preferring open ecosystems while evaluating **effective agency**:
+
+- Can the user leave?
+- Can data be exported?
+- Can another provider interoperate?
+- Can the system be repaired or replaced?
+- Is the knowledge needed to maintain it available?
+
+## Claim 6 — Repairability has real agency and resource value
+
+**Grade: Strong design/economic mechanism; context-specific limits**
+
+Repairability can extend product life, preserve ownership, reduce replacement costs, and support independent repair ecosystems.
+
+But repair rights and product design interact with:
+
+- batteries;
+- high voltage;
+- medical devices;
+- radio certification;
+- waterproofing;
+- cybersecurity;
+- calibration;
+- warranty;
+- safety-critical systems.
+
+**Doctrine implication:** Prefer repairability where practical, with safety and security constraints made explicit rather than used as blanket excuses or ignored entirely.
+
+## Claim 7 — Offline resilience can matter
+
+**Grade: Context-dependent resilience principle**
+
+A system that completely fails when a network, vendor, cloud service, account, or authentication system is unavailable may create avoidable fragility.
+
+Offline capability can be especially valuable for:
+
+- emergency information;
+- essential documents;
+- local control;
+- field work;
+- poor connectivity;
+- disasters;
+- travel;
+- long-lived equipment.
+
+Cloud services can also increase resilience through replication, remote backup, centralized patching, and professional operations.
+
+**Doctrine implication:** Ask which failure modes matter and design redundancy accordingly. “Local good / cloud bad” is too crude.
+
+## Claim 8 — Human oversight of AI is not automatically meaningful
+
+**Grade: Strong human-factors concern / current risk-management principle**
+
+A nominal human reviewer may:
+
+- rubber-stamp automated recommendations;
+- lack enough time;
+- lack expertise;
+- lack access to underlying evidence;
+- be unable to override the system;
+- become biased toward automation;
+- carry liability without real control.
+
+NIST’s AI Risk Management Framework emphasizes governance, measurement, transparency, human-AI configuration, and context rather than treating “human in the loop” as a magic safety phrase.
+
+Official source:
+- NIST AI Risk Management Framework: https://www.nist.gov/itl/ai-risk-management-framework
+
+**Doctrine implication:** Human review should be judged by **real authority, information, time, expertise, and appeal**, not by the presence of a human-shaped checkbox.
+
+## Claim 9 — Automation can preserve skill or erode skill depending on design
+
+**Grade: Working hypothesis with strong domain variation**
+
+Automation can:
+
+- remove repetitive work;
+- improve consistency;
+- expand capability;
+- reduce physical danger;
+- provide tutoring or scaffolding;
+- free attention for higher-level tasks.
+
+It can also:
+
+- reduce practice;
+- hide causal structure;
+- create dependency;
+- weaken error detection;
+- make recovery difficult when automation fails.
+
+**Doctrine implication:** Do not use “deskilling” as an automatic anti-automation argument.
+
+Ask:
+
+- Which skill still needs to exist?
+- Who needs it?
+- How often must it be practiced?
+- What happens when automation fails?
+- Can the tool teach while assisting?
+
+## Claim 10 — More user choice is not automatically more agency
+
+**Grade: Corrective principle**
+
+A product with hundreds of settings can create less practical control than one with sensible defaults and a few meaningful choices.
+
+Agency depends on:
+
+- comprehensibility;
+- reversibility;
+- defaults;
+- real alternatives;
+- consequence visibility;
+- ability to exit;
+- time required to manage the system.
+
+Human Scale should prefer **legible control**, not maximum configuration.
+
+## Claim 11 — Centralization can create both capability and dependency
+
+**Grade: Structural tradeoff**
+
+Central systems can provide:
+
+- scale;
+- expertise;
+- security operations;
+- coordination;
+- standardization;
+- network effects;
+- lower unit costs.
+
+They can also create:
+
+- concentration of power;
+- single points of policy control;
+- switching costs;
+- surveillance capacity;
+- correlated failure;
+- dependency.
+
+Decentralized systems can distribute control while creating fragmentation, duplicated effort, inconsistent maintenance, poor usability, or weak accountability.
+
+**Doctrine implication:** Centralization is another scale question to test rather than a moral category.
+
+---
+
+# Recommended Chapter Changes
+
+## Change 1 — Core thesis
+
+Keep:
+
+> Technology should expand human capability without requiring human captivity.
+
+Add:
+
+> Captivity is not measured by whether a system is modern, centralized, proprietary, or cloud-based. Measure practical exit, dependency, attention cost, control, failure modes, privacy, safety, and who holds consequential power.
+
+## Change 2 — Quiet technology
+
+Use:
+
+> Technology should demand attention in proportion to the task and return attention when the task is complete.
+
+## Change 3 — Openness
+
+Replace “open is always better” with:
+
+> Prefer open standards, portability, interoperability, documented interfaces, and repair where they create credible exit and resilience without unacceptable safety, privacy, or security costs.
+
+## Change 4 — AI oversight
+
+Use:
+
+> A human reviewer counts only when the person has enough information, authority, time, competence, and appeal power to meaningfully disagree with the machine.
+
+## Change 5 — Automation and skill
+
+Use:
+
+> Automate drudgery while identifying which human skills must remain practiced for judgment, development, safety, recovery, creativity, or dignity.
+
+---
+
+# What Chapter 5 Gets Right
+
+The chapter is strongest when it says:
+
+- technology is a tool, not destiny;
+- exit matters;
+- portability matters;
+- ownership and repair matter;
+- attention is an important design resource;
+- offline fallback can matter;
+- AI should augment judgment rather than merely obscure it;
+- technology should sometimes disappear when its task is complete;
+- convenience can create hidden dependency.
+
+It is weakest when openness, locality, quietness, or repairability are treated as universal proxies for human flourishing.
+
+---
+
+# What Would Change Our Minds?
+
+Human Scale should weaken its preferred technology principles if evidence shows that:
+
+- closed systems consistently provide much greater safety, accessibility, security, longevity, or usability without meaningful dependency costs;
+- users rarely value portability or repair even when those options are genuinely usable and affordable;
+- offline capability creates more security, maintenance, and reliability problems than resilience value in a given domain;
+- quiet interfaces cause important information to be missed or reduce task performance;
+- automation preserves or increases skill through better training and feedback;
+- centralized services are substantially more resilient than distributed alternatives for the relevant failure modes;
+- open interfaces create abuse or privacy risks that cannot be mitigated without undermining their purpose.
+
+Human Scale should also strengthen its position where credible exit, repair, portability, or calmer interfaces repeatedly produce measurable gains.
+
+---
+
+# Result of Audit 05
+
+**Chapter 5 survives, but openness becomes a means rather than an identity, and quiet technology becomes “attention proportional to the task.”**
+
+The stronger principle is:
+
+> Technology should expand human capability while preserving legible control, credible exit, proportionate attention, acceptable failure modes, and real human authority over consequential decisions.
+
+The best technology does not have to be small, local, open source, offline, or invisible.
+
+It has to justify what it asks humans to surrender.

--- a/human-scale/evidence/technology/index.html
+++ b/human-scale/evidence/technology/index.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Evidence Audit 05 — Technology Under Pressure</title>
+  <meta name="description" content="A Human Scale evidence audit of attention, open systems, repairability, portability, offline resilience, AI oversight, automation, skill, and centralization." />
+  <meta name="theme-color" content="#07111f" />
+  <link rel="canonical" href="https://tmsteph.com/human-scale/evidence/technology/" />
+  <meta property="og:title" content="Evidence Audit 05 — Technology Under Pressure" />
+  <meta property="og:description" content="Openness is a means, not an identity. Attention should be proportional to the task." />
+  <meta property="og:url" content="https://tmsteph.com/human-scale/evidence/technology/" />
+  <meta property="og:type" content="article" />
+  <meta name="twitter:card" content="summary" />
+  <link rel="icon" href="../../../favicon.ico" type="image/x-icon" />
+  <script defer src="/_vercel/analytics/script.js"></script>
+  <style>
+    :root{color-scheme:dark;--bg:#07111f;--panel:#0c192a;--text:#edf3fa;--muted:#aab9ca;--line:#243850;--sky:#7bcaff;--green:#a9ddb0;--sun:#ffe18a;--rose:#ffb8be}*{box-sizing:border-box}body{margin:0;font-family:Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;color:var(--text);line-height:1.72;background:radial-gradient(circle at 12% 0%,rgba(123,202,255,.11),transparent 34rem),var(--bg)}a{color:var(--sky)}nav,main{width:min(100% - 2rem,900px);margin:0 auto}nav{padding:1.2rem 0;color:var(--muted);display:flex;justify-content:space-between;gap:1rem}nav a{color:var(--muted);text-decoration:none}header{width:min(100% - 2rem,900px);margin:0 auto;padding:5rem 0 4rem;text-align:center}.eyebrow{color:var(--green);font-size:.78rem;font-weight:850;letter-spacing:.15em;text-transform:uppercase}h1{margin:.7rem 0 1rem;font-size:clamp(2.8rem,8vw,5.3rem);line-height:.98;letter-spacing:-.05em}h2{margin:0 0 1rem;font-size:clamp(1.8rem,5vw,2.7rem);line-height:1.08}h3{margin:.2rem 0 .55rem;font-size:1.16rem}.lead{max-width:780px;margin:0 auto;color:var(--muted);font-size:clamp(1.08rem,2.5vw,1.3rem)}.thesis{max-width:820px;margin:2rem auto 0;padding:1.35rem;border:1px solid rgba(255,225,138,.28);border-radius:18px;background:rgba(255,225,138,.045);color:#fff4cf;font-weight:780;font-size:1.18rem}section{padding:3rem 0;border-top:1px solid var(--line)}.callout{padding:1.25rem 1.35rem;border-left:4px solid var(--green);border-radius:0 14px 14px 0;background:var(--panel)}.claim{padding:1.2rem;margin:1rem 0;border:1px solid var(--line);border-radius:15px;background:linear-gradient(145deg,rgba(16,33,55,.9),rgba(8,19,34,.9))}.claim p{color:var(--muted);margin:.5rem 0}.tag{display:inline-block;margin-bottom:.65rem;padding:.25rem .55rem;border:1px solid var(--line);border-radius:999px;font-size:.76rem;font-weight:850}.strong{color:#dff6e2;border-color:rgba(169,221,176,.34);background:rgba(169,221,176,.06)}.moderate{color:#ddecff;border-color:rgba(123,202,255,.34);background:rgba(123,202,255,.06)}.revise{color:#fff0c1;border-color:rgba(255,225,138,.34);background:rgba(255,225,138,.055)}.value{color:#ffd9dd;border-color:rgba(255,184,190,.3);background:rgba(255,184,190,.05)}.changes{display:grid;gap:.8rem}.change{padding:1rem;border:1px solid var(--line);border-radius:13px;background:rgba(255,255,255,.025)}.change strong{color:var(--sun)}.closing{text-align:center}.closing strong{display:block;margin:1.7rem auto;color:var(--sun);font-size:clamp(1.6rem,4.6vw,2.35rem);line-height:1.15}footer{margin-top:2rem;padding:2.5rem 1rem 3rem;border-top:1px solid var(--line);text-align:center;color:var(--muted)}footer a{text-decoration:none}@media(max-width:600px){nav{display:block}nav span{display:block;margin-top:.4rem}header{padding-top:4rem}}
+  </style>
+</head>
+<body>
+  <nav><a href="../index.html">← Evidence Atlas</a><span>Audit 05 · Technology</span></nav>
+  <header><div class="eyebrow">Claim-by-claim pressure test</div><h1>Technology Under Pressure</h1><p class="lead">“Technology should serve human life” is a value. Evidence has to tell us what a particular system actually asks people to surrender and what it gives back.</p><div class="thesis">Openness is a means, not an identity. Attention should be proportional to the task.</div></header>
+  <main>
+    <section><h2>Summary judgment</h2><p>Keep agency, exit, portability, interoperability, repair and calm technology as Human Scale values. Stop treating local, open-source, offline, decentralized or quiet systems as automatically more humane.</p><div class="callout"><strong>The real test:</strong> legible control, credible exit, proportionate attention, acceptable failure modes, and meaningful human authority over consequential decisions.</div></section>
+
+    <section><h2>What survives strongly</h2>
+      <article class="claim"><span class="tag strong">Strong general principle</span><h3>Interface design can steer behavior.</h3><p>Defaults, friction, salience, button hierarchy, prompts, subscriptions and recommendation systems are not neutral. The FTC has documented deceptive “dark pattern” designs that manipulate consumer choices.</p><p><a href="https://www.ftc.gov/reports/bringing-dark-patterns-light" rel="noopener">FTC — Bringing Dark Patterns to Light ↗</a></p></article>
+      <article class="claim"><span class="tag moderate">Strong in task contexts</span><h3>Attention costs should be measured by mechanism.</h3><p>Interruptions and task switching can impair performance in specific settings, but “screen time” is too broad to function as one psychological exposure.</p></article>
+      <article class="claim"><span class="tag strong">Architectural mechanism</span><h3>Portability and interoperability can reduce dependency.</h3><p>Open standards, exportable data and substitutable interfaces can create credible exit. They still interact with security, privacy, support, intellectual property and usability.</p></article>
+      <article class="claim"><span class="tag strong">Human-factors concern</span><h3>“Human in the loop” is not automatically meaningful oversight.</h3><p>A reviewer needs actual authority, time, information, competence and the power to disagree or appeal.</p><p><a href="https://www.nist.gov/itl/ai-risk-management-framework" rel="noopener">NIST AI Risk Management Framework ↗</a></p></article>
+    </section>
+
+    <section><h2>What becomes more precise</h2>
+      <article class="claim"><span class="tag value">Value + design hypothesis</span><h3>Quiet technology becomes attention proportional to the task.</h3><p>An emergency alert should demand attention. A calculator should not. Test task completion, missed information, interruption, errors and time rather than treating silence itself as virtue.</p></article>
+      <article class="claim"><span class="tag revise">Corrective principle</span><h3>Open source is not identical to user freedom.</h3><p>Open software can be unusable, insecurely configured, abandoned or dependent on centralized services. Proprietary systems can sometimes provide accessibility, maintenance and security. Measure effective agency.</p></article>
+      <article class="claim"><span class="tag value">Context-specific value</span><h3>Repairability matters, with limits.</h3><p>Repair can extend product life and reduce switching costs, while batteries, high voltage, medical devices, radio certification, calibration and cybersecurity can create legitimate constraints.</p></article>
+      <article class="claim"><span class="tag revise">Resilience tradeoff</span><h3>Offline capability is not automatically more resilient.</h3><p>Local fallback can survive network/vendor failure; cloud services can provide replication, remote backup and professional operations. Design around the failure modes that matter.</p></article>
+      <article class="claim"><span class="tag revise">Working hypothesis</span><h3>Automation may preserve or erode skill.</h3><p>Ask which skills still need practice for judgment, safety, recovery, development or creativity instead of using “deskilling” as an automatic anti-automation argument.</p></article>
+      <article class="claim"><span class="tag revise">Corrective principle</span><h3>More settings do not automatically create more agency.</h3><p>Legible defaults, reversibility and credible alternatives may matter more than hundreds of configuration options.</p></article>
+      <article class="claim"><span class="tag revise">Scale tradeoff</span><h3>Centralization can create capability and dependency.</h3><p>Scale can bring expertise, coordination and lower unit costs while concentrating power and correlated failure. Decentralization can distribute control while fragmenting maintenance and accountability.</p></article>
+    </section>
+
+    <section><h2>Recommended chapter changes</h2><div class="changes">
+      <div class="change"><strong>Core:</strong> Keep “Technology should expand human capability without requiring human captivity.” Define captivity through practical exit, dependency, attention cost, privacy, failure modes and power.</div>
+      <div class="change"><strong>Quiet:</strong> Technology should demand attention in proportion to the task and return it when the task is complete.</div>
+      <div class="change"><strong>Open:</strong> Prefer standards, portability, interoperability, documented interfaces and repair where they create credible exit without unacceptable safety/privacy/security costs.</div>
+      <div class="change"><strong>AI oversight:</strong> A human reviewer counts only when the person has enough information, authority, time and competence to meaningfully disagree.</div>
+      <div class="change"><strong>Automation:</strong> Remove drudgery while identifying which human skills still need practice for safety, judgment, development, recovery or dignity.</div>
+    </div></section>
+
+    <section><h2>What Chapter 5 gets right</h2><p>Technology is a tool, not destiny. Exit, portability, ownership, repair, attention, fallback, judgment and dependency all matter. Convenience can conceal power.</p><div class="callout">The chapter is weakest when openness, locality, decentralization, quietness or repairability become proxies for human flourishing rather than mechanisms to evaluate.</div></section>
+
+    <section><h2>What would change our minds?</h2><p>We should weaken preferred principles if closed systems consistently provide much greater safety/accessibility/security without meaningful dependency costs; offline features create more fragility than resilience; calm interfaces cause important information loss; automation reliably increases skill; or centralized services repeatedly outperform distributed alternatives on the actual failure modes that matter.</p><p>We should strengthen them where portability, repair, credible exit or calmer interfaces repeatedly produce measurable gains.</p></section>
+
+    <section class="closing"><h2>Result of Audit 05</h2><strong>Technology should expand human capability while preserving legible control, credible exit, proportionate attention, acceptable failure modes, and real human authority over consequential decisions.</strong><p>The best technology does not have to be small, local, open source, offline or invisible. It has to justify what it asks humans to surrender.</p></section>
+  </main>
+  <footer><a href="../index.html">Evidence Atlas</a> · <a href="../../technology/index.html">Chapter 5</a> · <a href="../../lab/index.html">Lab</a> · <a href="../../index.html">Doctrine</a></footer>
+</body>
+</html>


### PR DESCRIPTION
## What changed
- Added **Evidence Audit 05: Technology Under Pressure** with full source and public page.
- Added **Chapter 14: Attention & Media — What Gets to Enter the Mind** with full source and public page.

## Technology corrections
The audit keeps agency, exit, portability, repairability, interoperability, calm technology, and meaningful human oversight as Human Scale values while removing automatic moral status from open source, local compute, offline systems, decentralization, repair, or quiet interfaces. The stronger test is legible control, credible exit, proportionate attention, acceptable failure modes, and real authority over consequential decisions.

## Attention & Media
The new chapter covers finite attention, persuasion versus manipulation, engagement versus value, screen-time overgeneralization, youth safeguards, news, algorithmic ranking, advertising, political persuasion, AI-generated media, provenance, speech versus amplification, feed control, dark patterns, and direct publishing.

## Human Scale advertising standard
Human Scale now explicitly binds its own promotion to the chapter: identify the source, no fabricated grassroots support, no repeated unwanted outreach, no sensitive-vulnerability targeting, no deceptive scarcity, correct factual errors, separate belief from evidence, promote useful tools/results, and make leaving easy.

Central rule: **Every advertisement should leave the audience with something useful even if they never become a Human Scale supporter.**