### PR TITLE
simplify Human Scale newcomer path

### DIFF
--- a/human-scale/audit/index.html
+++ b/human-scale/audit/index.html
@@ -3,100 +3,133 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Human Scale Audit — How Human Is Your Environment?</title>
-  <meta name="description" content="A private, no-signup Human Scale Audit for movement, nature, time, community, place, work, and technological agency." />
-  <meta name="theme-color" content="#07111f" />
+  <title>Human Scale Check — How Well Does Daily Life Support You?</title>
+  <meta name="description" content="A private five-minute check of where daily life supports you and where it adds friction." />
+  <meta name="theme-color" content="#08111d" />
   <link rel="canonical" href="https://tmsteph.com/human-scale/audit/" />
-  <meta property="og:title" content="Human Scale Audit — How Human Is Your Environment?" />
-  <meta property="og:description" content="A private, no-signup audit of whether your everyday environment supports human life." />
+  <meta property="og:title" content="Human Scale Check" />
+  <meta property="og:description" content="Where does daily life support you, and where does it make things harder?" />
   <meta property="og:url" content="https://tmsteph.com/human-scale/audit/" />
   <meta property="og:type" content="website" />
   <meta name="twitter:card" content="summary" />
   <link rel="icon" href="../../favicon.ico" type="image/x-icon" />
   <script defer src="/_vercel/analytics/script.js"></script>
   <style>
-    :root{color-scheme:dark;--bg:#07111f;--panel:#0c192a;--text:#eef4fb;--muted:#aab9ca;--line:#263a52;--sky:#7bcaff;--green:#a9ddb0;--sun:#ffe18a;--rose:#ffb8be}
-    *{box-sizing:border-box}html{scroll-behavior:smooth}body{margin:0;font-family:Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;background:radial-gradient(circle at 10% 0%,rgba(123,202,255,.12),transparent 34rem),radial-gradient(circle at 92% 8%,rgba(169,221,176,.09),transparent 31rem),var(--bg);color:var(--text);line-height:1.65}a{color:var(--sky)}
-    .topbar{width:min(100% - 2rem,1020px);margin:0 auto;padding:1.2rem 0;display:flex;justify-content:space-between;gap:1rem;color:var(--muted);font-size:.93rem}.topbar a{color:var(--muted);text-decoration:none}
-    header{width:min(100% - 2rem,850px);margin:0 auto;padding:4.6rem 0 3.4rem;text-align:center}.eyebrow{color:var(--green);font-size:.78rem;font-weight:850;letter-spacing:.15em;text-transform:uppercase}h1{margin:.75rem 0 1rem;font-size:clamp(2.7rem,8vw,5rem);line-height:.98;letter-spacing:-.05em}h2{margin:0 0 .8rem;font-size:clamp(1.65rem,4.5vw,2.35rem);line-height:1.1}h3{margin:0;font-size:1.08rem}.lead{max-width:720px;margin:0 auto;color:var(--muted);font-size:clamp(1.05rem,2.3vw,1.25rem)}
-    main{width:min(100% - 2rem,850px);margin:0 auto;padding-bottom:5rem}.privacy{margin:1.8rem auto 0;padding:1rem 1.2rem;border:1px solid rgba(169,221,176,.32);border-radius:14px;background:rgba(169,221,176,.05);color:#dcf4df}.question{padding:1.35rem;margin:1rem 0;border:1px solid var(--line);border-radius:16px;background:linear-gradient(145deg,rgba(16,33,55,.92),rgba(8,19,34,.92))}.question p{margin:.45rem 0 .95rem;color:var(--muted)}.scale{display:grid;grid-template-columns:repeat(5,1fr);gap:.45rem}.choice{position:relative}.choice input{position:absolute;opacity:0;pointer-events:none}.choice label{min-height:3.2rem;display:grid;place-items:center;padding:.45rem;border:1px solid var(--line);border-radius:12px;background:rgba(255,255,255,.025);cursor:pointer;font-weight:750;color:var(--muted);text-align:center}.choice input:checked+label{border-color:var(--sky);background:rgba(123,202,255,.11);color:var(--text);box-shadow:0 0 0 1px rgba(123,202,255,.25)}.choice label:hover{border-color:#466786}.anchors{display:flex;justify-content:space-between;gap:1rem;margin-top:.55rem;color:var(--muted);font-size:.78rem}
-    .actions{display:flex;flex-wrap:wrap;gap:.8rem;margin:1.7rem 0}.btn{appearance:none;border:0;border-radius:999px;padding:.9rem 1.2rem;font:inherit;font-weight:800;cursor:pointer;text-decoration:none}.primary{background:var(--sky);color:#04101e}.secondary{border:1px solid var(--line);background:var(--panel);color:var(--text)}.status{min-height:1.5rem;color:var(--rose)}
-    #results{display:none;margin-top:2rem;padding-top:2.5rem;border-top:1px solid var(--line)}.scorebox{text-align:center;padding:2rem;border:1px solid rgba(255,225,138,.3);border-radius:20px;background:rgba(255,225,138,.045)}.score{font-size:clamp(3.6rem,12vw,6rem);font-weight:900;line-height:1;color:var(--sun)}.grade{margin:.6rem 0;font-size:1.35rem;font-weight:850}.result-copy{max-width:680px;margin:.8rem auto;color:var(--muted)}.domains{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:.8rem;margin-top:1.2rem}.domain{padding:1rem;border:1px solid var(--line);border-radius:14px;background:var(--panel)}.bar{height:.55rem;margin-top:.6rem;border-radius:999px;background:#17283b;overflow:hidden}.fill{height:100%;background:linear-gradient(90deg,var(--sky),var(--green));border-radius:999px}.next{margin-top:1.2rem;padding:1.2rem;border-left:4px solid var(--green);background:var(--panel);border-radius:0 14px 14px 0}.fine{color:var(--muted);font-size:.88rem}footer{border-top:1px solid var(--line);padding:2.5rem 1rem 3rem;text-align:center;color:var(--muted)}footer a{text-decoration:none}@media(max-width:600px){header{padding-top:3.6rem}.scale{gap:.3rem}.choice label{min-height:3rem;padding:.3rem;font-size:.84rem}}
+    :root{color-scheme:dark;--bg:#08111d;--panel:#101c2b;--text:#f2f5f8;--muted:#b7c2cf;--line:#26384d;--accent:#8bd0ff;--warm:#ffe39a;--green:#b6e3bd;--rose:#ffb9bf}
+    *{box-sizing:border-box}html{scroll-behavior:smooth}body{margin:0;background:var(--bg);color:var(--text);font-family:Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;line-height:1.6}a{color:var(--accent)}
+    .top,header,main{width:min(100% - 2rem,780px);margin:auto}.top{padding:1.2rem 0;color:var(--muted);font-size:.92rem}.top a{color:var(--muted);text-decoration:none}header{padding:4.2rem 0 3.2rem;text-align:center}.eyebrow{color:var(--green);font-size:.82rem;font-weight:800;letter-spacing:.1em;text-transform:uppercase}h1{margin:.65rem 0 1rem;font-size:clamp(2.8rem,9vw,5rem);line-height:.98;letter-spacing:-.045em}h2{font-size:clamp(1.65rem,5vw,2.3rem);line-height:1.1}.lead{max-width:620px;margin:auto;color:var(--muted);font-size:1.16rem}.note{margin:1.4rem auto 0;padding:1rem 1.1rem;border-radius:13px;background:var(--panel);color:var(--muted)}.note strong{color:var(--green)}
+    .question{padding:1.15rem 0;border-top:1px solid var(--line)}.question h3{margin:0 0 .8rem;font-size:1.08rem;line-height:1.35}.scale{display:grid;grid-template-columns:repeat(5,1fr);gap:.38rem}.choice{position:relative}.choice input{position:absolute;opacity:0;pointer-events:none}.choice label{display:grid;place-items:center;min-height:3.1rem;padding:.35rem;border:1px solid var(--line);border-radius:10px;background:var(--panel);color:var(--muted);cursor:pointer;text-align:center;font-size:.78rem;font-weight:750;line-height:1.15}.choice input:checked+label{border-color:var(--accent);background:rgba(139,208,255,.12);color:var(--text);box-shadow:0 0 0 1px rgba(139,208,255,.2)}
+    .actions{display:flex;gap:.75rem;flex-wrap:wrap;margin:1.6rem 0 2.5rem}.btn{appearance:none;border:0;border-radius:999px;padding:.9rem 1.2rem;font:inherit;font-weight:850;cursor:pointer;text-decoration:none}.primary{background:var(--accent);color:#07111c}.secondary{background:var(--panel);border:1px solid var(--line);color:var(--muted)}.status{color:var(--rose);min-height:1.4rem}
+    #results{display:none;padding:3rem 0;border-top:1px solid var(--line)}.result-head{padding:1.3rem;border-radius:15px;background:var(--panel);border-left:4px solid var(--warm)}.result-head strong{display:block;color:var(--warm);font-size:1.25rem}.result-head p{margin:.4rem 0 0;color:var(--muted)}.domains{display:grid;gap:.7rem;margin-top:1.2rem}.domain{padding:1rem 1.1rem;border:1px solid var(--line);border-radius:13px;background:var(--panel)}.row{display:flex;justify-content:space-between;gap:1rem}.level{color:var(--muted);font-size:.9rem}.bar{height:.48rem;margin-top:.65rem;border-radius:999px;background:#19283a;overflow:hidden}.fill{height:100%;background:var(--accent);border-radius:999px}.next{margin-top:1.5rem;padding:1.2rem;border-radius:14px;background:rgba(182,227,189,.07);border:1px solid rgba(182,227,189,.25)}.fine{color:var(--muted);font-size:.88rem}
+    footer{padding:2.5rem 1rem 3rem;border-top:1px solid var(--line);text-align:center;color:var(--muted);font-size:.9rem}footer a{color:var(--muted);text-decoration:none}
+    @media(max-width:520px){header{padding-top:3.5rem}.scale{gap:.25rem}.choice label{font-size:.68rem;min-height:3.25rem;padding:.2rem}}
   </style>
 </head>
 <body>
-  <nav class="topbar"><a href="../index.html">← Human Scale Doctrine</a><span>Audit · v0.1</span></nav>
+  <nav class="top"><a href="../start/index.html">← Step 1</a></nav>
   <header>
-    <div class="eyebrow">A five-minute environment check</div>
-    <h1>How human is your environment?</h1>
-    <p class="lead">Human Scale is partly about individual habits, but mostly about the conditions around us. This audit asks whether everyday life makes healthy, connected, capable human behavior easier or harder.</p>
-    <div class="privacy"><strong>Private by design:</strong> your answers are calculated in this browser. Nothing is submitted or stored on a server.</div>
+    <div class="eyebrow">Step 2 of 3 · Check your daily life</div>
+    <h1>Where does life feel hard?</h1>
+    <p class="lead">Answer 15 simple questions. This is not a test. It helps you see where daily life supports you and where it adds friction.</p>
+    <div class="note"><strong>Private:</strong> your answers stay in this browser. Nothing is sent or saved.</div>
   </header>
+
   <main>
     <form id="audit" novalidate>
       <div id="questions"></div>
       <p class="status" id="status" aria-live="polite"></p>
-      <div class="actions"><button class="btn primary" type="submit">See my Human Scale score</button><button class="btn secondary" type="button" id="reset">Reset</button></div>
+      <div class="actions"><button class="btn primary" type="submit">Show me my areas</button><button class="btn secondary" type="button" id="reset">Reset</button></div>
     </form>
 
     <section id="results" aria-live="polite">
-      <div class="scorebox"><div class="score" id="score">0</div><div class="grade" id="grade"></div><p class="result-copy" id="summary"></p></div>
+      <h2>Your daily-life map</h2>
+      <div class="result-head"><strong id="focusTitle"></strong><p id="focusCopy"></p></div>
       <div class="domains" id="domains"></div>
-      <div class="next" id="next"></div>
-      <div class="actions"><button class="btn primary" id="share" type="button">Share the audit</button><a class="btn secondary" href="../field-guide/index.html">Open the Field Guide</a><a class="btn secondary" href="../program/index.html">See what should change</a></div>
-      <p class="fine">This is a reflective tool, not a medical, psychological, or scientific diagnostic. The categories and weights are provisional and should improve as the Human Scale Evidence Atlas grows.</p>
+      <div class="next"><strong>Do not try to fix everything.</strong><p>Pick one area that feels hard. The next step gives you a few small things to try.</p><a class="btn primary" href="../try-one-thing/index.html">Step 3: Change one thing →</a></div>
+      <p class="fine">This is a reflection tool, not a medical or scientific test. We do not give one total score. These areas are different, and we do not know a fair way to combine them yet.</p>
     </section>
   </main>
-  <footer><a href="../start/index.html">Start Here</a> · <a href="../index.html">Doctrine</a> · <a href="../evidence/index.html">Evidence</a> · <a href="../share/index.html">Share</a><br />Human Scale · tmsteph.com</footer>
+
+  <footer>Human Scale · <a href="../index.html">Home</a> · <a href="../evidence/cross-cutting/audit-calibration/index.html">How we are testing this check</a></footer>
 
   <script>
     const questions = [
-      {d:'Body',q:'Most days, my environment makes ordinary physical movement easy.',h:'Walking, carrying, climbing, standing, playing, exercise, or physical work can happen without heroic planning.'},
-      {d:'Body',q:'I can usually get adequate sleep without my schedule constantly fighting it.',h:'Work, commuting, noise, caregiving, screens, or institutional demands do not routinely make sufficient sleep impossible.'},
-      {d:'Living world',q:'I have easy access to daylight, fresh air, plants, trees, soil, water, or other living systems.',h:'Nature is part of ordinary life rather than something available only on special trips.'},
-      {d:'Living world',q:'I have a realistic chance to grow, tend, cook, repair, make, or care for something tangible.',h:'I am not restricted to consuming finished products and digital experiences.'},
-      {d:'Community',q:'There are people nearby who know me and whom I can realistically help or ask for help.',h:'Belonging includes repeated relationships and some degree of reciprocity.'},
-      {d:'Community',q:'I have places where I can spend time with other people without needing to buy much.',h:'Parks, libraries, homes, courtyards, faith communities, plazas, clubs, workshops, or other third places count.'},
-      {d:'Time',q:'A meaningful portion of my week belongs to me rather than work, commuting, bureaucracy, or recovery from them.',h:'There is usable time for family, friends, rest, craft, civic life, nature, play, or contemplation.'},
-      {d:'Time',q:'My schedule is predictable enough to plan a human life around it.',h:'I can make commitments, coordinate care, and know roughly when I am available.'},
-      {d:'Agency',q:'I can understand and influence at least some of the systems that strongly affect my life.',h:'Examples include workplace rules, housing, school, neighborhood decisions, technology, finances, or public services.'},
-      {d:'Agency',q:'The technology I depend on gives me meaningful control and exit.',h:'I can export important data, switch tools, repair or replace devices, and survive at least some outages or platform failures.'},
-      {d:'Place',q:'Daily needs are close enough that ordinary life does not require excessive travel.',h:'Food, school, work, recreation, services, people, and nature are not all needlessly separated.'},
-      {d:'Place',q:'My surroundings make it reasonably safe and pleasant to walk, sit, gather, and exist outside.',h:'Shade, crossings, sidewalks or paths, seating, public space, accessibility, and traffic conditions matter.'},
-      {d:'Security',q:'A normal setback would not immediately destroy my ability to meet basic needs.',h:'Income, savings, benefits, family/community support, housing stability, or other buffers create some room to recover.'},
-      {d:'Security',q:'I have some believable path toward greater ownership, competence, or independence over time.',h:'Skills, tools, savings, a business, housing, productive assets, shared ownership, or community capacity can expand my choices.'},
-      {d:'Meaning',q:'My life contains activities that feel worthwhile beyond consumption, status, or keeping up.',h:'Care, work, service, faith, art, music, craft, study, nature, family, friendship, building, or other forms of purpose count.'}
+      {d:'Body',q:'My day makes it easy to move my body.'},
+      {d:'Body',q:'I can usually get enough sleep.'},
+      {d:'Nature',q:'I can easily get outside and be around nature.'},
+      {d:'Nature',q:'I can grow, care for, fix, or make something real.'},
+      {d:'People',q:'I have people nearby I can count on.'},
+      {d:'People',q:'I have places to be with people without spending much money.'},
+      {d:'Time',q:'I have some free time that really feels like mine.'},
+      {d:'Time',q:'My schedule is steady enough to plan around.'},
+      {d:'Agency',q:'I can understand or influence some of the systems that shape my life.'},
+      {d:'Agency',q:'I can change or leave important tech tools if I need to.'},
+      {d:'Place',q:'Most things I need each day are not too far away.'},
+      {d:'Place',q:'It feels safe and comfortable to walk, sit, or spend time outside.'},
+      {d:'Security',q:'One normal setback would not put my basic needs at risk right away.'},
+      {d:'Security',q:'I have a real path toward more skill, savings, ownership, or freedom.'},
+      {d:'Meaning',q:'My life has things that feel meaningful to me.'}
     ];
-    const labels=['Almost never','Rarely','Sometimes','Often','Usually'];
+    const labels=['Never','Rarely','Sometimes','Often','Usually'];
     const root=document.getElementById('questions');
+
     questions.forEach((item,i)=>{
-      const el=document.createElement('section');el.className='question';
-      el.innerHTML=`<h3>${i+1}. ${item.q}</h3><p>${item.h}</p><div class="scale">${labels.map((l,n)=>`<div class="choice"><input id="q${i}-${n}" type="radio" name="q${i}" value="${n}"><label for="q${i}-${n}">${n}</label></div>`).join('')}</div><div class="anchors"><span>0 · almost never</span><span>4 · usually</span></div>`;
+      const el=document.createElement('section');
+      el.className='question';
+      el.innerHTML=`<h3>${i+1}. ${item.q}</h3><div class="scale">${labels.map((label,n)=>`<div class="choice"><input id="q${i}-${n}" type="radio" name="q${i}" value="${n}"><label for="q${i}-${n}">${label}</label></div>`).join('')}</div>`;
       root.appendChild(el);
     });
-    const form=document.getElementById('audit'), status=document.getElementById('status'), results=document.getElementById('results');
-    function classification(p){
-      if(p<35)return ['High-friction environment','Your surroundings are asking you to compensate constantly. Pick one major friction to reduce rather than trying to optimize everything at once.'];
-      if(p<55)return ['More friction than support','Some important conditions are working, but everyday life still makes several human needs harder than they need to be.'];
-      if(p<75)return ['Mixed human-scale conditions','You have a meaningful base to build from. The biggest gains may come from improving the weakest domain rather than polishing the strongest.'];
-      if(p<90)return ['Supportive environment','A lot of your daily environment supports human life. Protect those conditions and look for ways to extend them to other people.'];
-      return ['Strongly human-scale environment','Your answers describe unusually supportive conditions. The interesting question now is how durable, accessible, and shareable those conditions are.'];
+
+    const form=document.getElementById('audit');
+    const status=document.getElementById('status');
+    const results=document.getElementById('results');
+
+    function level(p){
+      if(p<35) return 'Needs support';
+      if(p<60) return 'Often hard';
+      if(p<80) return 'Mixed';
+      return 'Usually supportive';
     }
+
     form.addEventListener('submit',e=>{
-      e.preventDefault(); const values=[], missing=[];
-      questions.forEach((_,i)=>{const x=form.querySelector(`input[name=q${i}]:checked`);if(!x)missing.push(i+1);else values.push(Number(x.value));});
-      if(missing.length){status.textContent=`Answer every question first. Missing: ${missing.join(', ')}.`;document.querySelector(`input[name=q${missing[0]-1}]`)?.closest('.question')?.scrollIntoView({behavior:'smooth',block:'center'});return;}
-      status.textContent=''; const max=questions.length*4, total=values.reduce((a,b)=>a+b,0), pct=Math.round(total/max*100), [grade,summary]=classification(pct);
-      document.getElementById('score').textContent=pct; document.getElementById('grade').textContent=grade; document.getElementById('summary').textContent=summary;
-      const domains={};questions.forEach((x,i)=>{domains[x.d]??={sum:0,max:0};domains[x.d].sum+=values[i];domains[x.d].max+=4;});
-      const domainEl=document.getElementById('domains');domainEl.innerHTML='';
-      Object.entries(domains).sort((a,b)=>(a[1].sum/a[1].max)-(b[1].sum/b[1].max)).forEach(([name,x])=>{const p=Math.round(x.sum/x.max*100);const d=document.createElement('div');d.className='domain';d.innerHTML=`<strong>${name}</strong><span style="float:right">${p}%</span><div class="bar"><div class="fill" style="width:${p}%"></div></div>`;domainEl.appendChild(d);});
-      const weakest=Object.entries(domains).sort((a,b)=>(a[1].sum/a[1].max)-(b[1].sum/b[1].max))[0][0];
-      document.getElementById('next').innerHTML=`<strong>Start with ${weakest.toLowerCase()}.</strong> Ask: is the friction mostly a habit I can change, a household constraint we can redesign, or a system that many people around me are also compensating for? If it is shared, that is where personal adaptation becomes civic work.`;
-      results.style.display='block';results.scrollIntoView({behavior:'smooth'});results.dataset.score=pct;
+      e.preventDefault();
+      const values=[]; const missing=[];
+      questions.forEach((_,i)=>{
+        const x=form.querySelector(`input[name=q${i}]:checked`);
+        if(!x) missing.push(i+1); else values.push(Number(x.value));
+      });
+      if(missing.length){
+        status.textContent=`Please answer every question. Missing: ${missing.join(', ')}.`;
+        document.querySelector(`input[name=q${missing[0]-1}]`)?.closest('.question')?.scrollIntoView({behavior:'smooth',block:'center'});
+        return;
+      }
+      status.textContent='';
+      const domains={};
+      questions.forEach((item,i)=>{
+        domains[item.d]??={sum:0,max:0};
+        domains[item.d].sum+=values[i];
+        domains[item.d].max+=4;
+      });
+      const sorted=Object.entries(domains).sort((a,b)=>(a[1].sum/a[1].max)-(b[1].sum/b[1].max));
+      const weakest=sorted[0][0];
+      document.getElementById('focusTitle').textContent=`Start with ${weakest.toLowerCase()}.`;
+      document.getElementById('focusCopy').textContent='This area had the most friction in your answers. It may be a useful place to look first.';
+      const domainEl=document.getElementById('domains');
+      domainEl.innerHTML='';
+      sorted.forEach(([name,x])=>{
+        const pct=Math.round((x.sum/x.max)*100);
+        const d=document.createElement('div');
+        d.className='domain';
+        d.innerHTML=`<div class="row"><strong>${name}</strong><span class="level">${level(pct)}</span></div><div class="bar"><div class="fill" style="width:${pct}%"></div></div>`;
+        domainEl.appendChild(d);
+      });
+      results.style.display='block';
+      results.scrollIntoView({behavior:'smooth'});
     });
-    document.getElementById('reset').addEventListener('click',()=>{form.reset();status.textContent='';results.style.display='none';window.scrollTo({top:0,behavior:'smooth'});});
-    document.getElementById('share').addEventListener('click',async()=>{const score=results.dataset.score||'';const text=`I tried the Human Scale Audit${score?` and scored ${score}/100`:''}. It asks whether everyday life supports movement, nature, time, community, place and agency — not just whether you have good habits.`;const url='https://tmsteph.com/human-scale/audit/';try{if(navigator.share){await navigator.share({title:'Human Scale Audit',text,url});}else{await navigator.clipboard.writeText(`${text} ${url}`);document.getElementById('share').textContent='Copied share text';}}catch(e){}}
+
+    document.getElementById('reset').addEventListener('click',()=>{
+      form.reset(); status.textContent=''; results.style.display='none'; window.scrollTo({top:0,behavior:'smooth'});
+    });
   </script>
 </body>
 </html>

--- a/human-scale/index.html
+++ b/human-scale/index.html
@@ -3,78 +3,78 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>The Human Scale Doctrine — Thomas Stephens</title>
-  <meta name="description" content="Human Scale: a living doctrine for keeping modern capability while rebuilding civilization around human flourishing, agency, health, community, education, time, and the living world." />
-  <meta name="theme-color" content="#07111f" />
+  <title>Human Scale — A Better Way to Live With Modern Life</title>
+  <meta name="description" content="Human Scale is a simple idea: keep what modern life does well, and make everyday life fit human beings better." />
+  <meta name="theme-color" content="#08111d" />
   <link rel="canonical" href="https://tmsteph.com/human-scale/" />
-  <link rel="alternate" type="application/rss+xml" title="Human Scale RSS" href="https://tmsteph.com/human-scale/feed.xml" />
-  <meta property="og:title" content="The Human Scale Doctrine" />
-  <meta property="og:description" content="Keep the science. Keep the computers. Recover the human world." />
+  <meta property="og:title" content="Human Scale" />
+  <meta property="og:description" content="Modern life is powerful. It should also feel human." />
   <meta property="og:url" content="https://tmsteph.com/human-scale/" />
   <meta property="og:type" content="website" />
   <meta name="twitter:card" content="summary" />
   <link rel="icon" href="../favicon.ico" type="image/x-icon" />
   <script defer src="/_vercel/analytics/script.js"></script>
-  <script type="application/ld+json">{"@context":"https://schema.org","@type":"CreativeWork","name":"The Human Scale Doctrine","author":{"@type":"Person","name":"Thomas Stephens","url":"https://tmsteph.com/"},"url":"https://tmsteph.com/human-scale/","dateModified":"2026-08-10","version":"0.17","description":"A living doctrine for building modern civilization around human flourishing."}</script>
+  <script type="application/ld+json">{"@context":"https://schema.org","@type":"CreativeWork","name":"Human Scale","author":{"@type":"Person","name":"Thomas Stephens","url":"https://tmsteph.com/"},"url":"https://tmsteph.com/human-scale/","dateModified":"2026-08-11","version":"0.18","description":"A living project about making modern life work better for human beings."}</script>
   <style>
-    :root{color-scheme:dark;--bg:#07111f;--panel:#0b1728;--text:#e8eef7;--muted:#a9b8cb;--line:#22344c;--sky:#78c8ff;--sun:#ffe28a;--green:#a9ddb0}
-    *{box-sizing:border-box}html{scroll-behavior:smooth}body{margin:0;font-family:Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;background:radial-gradient(circle at 15% 0%,rgba(120,200,255,.12),transparent 34rem),radial-gradient(circle at 90% 10%,rgba(158,216,170,.08),transparent 30rem),var(--bg);color:var(--text);line-height:1.72}a{color:var(--sky)}
-    .topbar{max-width:1050px;margin:0 auto;padding:1.25rem 1.4rem 0;display:flex;justify-content:space-between;gap:1rem;color:var(--muted);font-size:.92rem}.topbar a{color:var(--muted);text-decoration:none}.mini{display:flex;gap:.8rem;flex-wrap:wrap;justify-content:flex-end}
-    header{max-width:900px;margin:0 auto;padding:6rem 1.4rem 4.2rem;text-align:center}.eyebrow{color:var(--sky);font-size:.78rem;font-weight:800;letter-spacing:.16em;text-transform:uppercase}h1{margin:.75rem 0 1.1rem;font-size:clamp(3rem,9vw,6rem);line-height:.97;letter-spacing:-.055em}h2{margin:0 0 1rem;font-size:clamp(1.9rem,5vw,2.8rem);line-height:1.08;letter-spacing:-.035em}h3{margin:0;font-size:1.12rem;line-height:1.3}p{margin:.9rem 0}.lead{max-width:720px;margin:0 auto;color:var(--muted);font-size:clamp(1.08rem,2.6vw,1.35rem)}.thesis{max-width:780px;margin:2.3rem auto 0;padding:1.35rem 1.5rem;border:1px solid rgba(255,226,138,.28);border-radius:18px;background:rgba(255,226,138,.055);color:#fff4cf;font-size:clamp(1.25rem,3vw,1.7rem);font-weight:750}
-    main{width:min(100% - 2rem,880px);margin:0 auto;padding-bottom:5rem}section{padding:3.1rem 0;border-top:1px solid var(--line)}.muted{color:var(--muted)}.callout{margin:1.7rem 0 0;padding:1.3rem 1.4rem;border-left:4px solid var(--sky);border-radius:0 14px 14px 0;background:var(--panel);font-size:1.1rem}.three,.four{display:grid;gap:1rem;margin-top:1.4rem}.three{grid-template-columns:repeat(3,1fr)}.four{grid-template-columns:repeat(2,1fr)}.card{padding:1.2rem;border:1px solid var(--line);border-radius:16px;background:var(--panel)}.card p{margin-bottom:0;color:var(--muted)}.needs{display:flex;flex-wrap:wrap;gap:.6rem;padding:0;margin:1.4rem 0;list-style:none}.needs li{padding:.42rem .75rem;border:1px solid var(--line);border-radius:999px;background:rgba(255,255,255,.025);color:#dbe6f3}.theses{display:grid;gap:.9rem;margin-top:1.5rem}.thesis-card{display:grid;grid-template-columns:2.7rem 1fr;gap:1rem;padding:1.15rem;border:1px solid var(--line);border-radius:16px;background:linear-gradient(145deg,rgba(16,32,55,.82),rgba(8,19,34,.82))}.number{width:2.7rem;height:2.7rem;display:grid;place-items:center;border-radius:50%;background:rgba(120,200,255,.1);color:var(--sky);font-weight:850}.thesis-card p{margin:.4rem 0 0;color:var(--muted)}.feature,.chapter{display:block;padding:1.35rem;border-radius:16px;color:var(--text);text-decoration:none}.feature{border:1px solid rgba(169,221,176,.34);background:linear-gradient(145deg,rgba(169,221,176,.09),rgba(120,200,255,.04))}.feature strong{display:block;color:#c8f2cf;font-size:1.08rem}.feature span,.chapter span{display:block;margin-top:.4rem;color:var(--muted)}.chapter{margin-top:.85rem;border:1px solid rgba(120,200,255,.3);background:rgba(120,200,255,.06)}.chapter strong{color:var(--sky);font-size:1.04rem}.closing{text-align:center}.closing strong{display:block;max-width:720px;margin:2rem auto 0;color:var(--sun);font-size:clamp(1.6rem,5vw,2.5rem);line-height:1.15;letter-spacing:-.035em}.version{margin-top:2rem;color:var(--muted);font-size:.9rem}footer{padding:2.5rem 1.4rem 3.5rem;border-top:1px solid var(--line);text-align:center;color:var(--muted)}footer a{text-decoration:none}@media(max-width:700px){header{padding-top:4.5rem}.three,.four{grid-template-columns:1fr}.topbar{display:block}.mini{justify-content:flex-start;margin-top:.5rem}}
+    :root{color-scheme:dark;--bg:#08111d;--panel:#101c2b;--text:#f2f5f8;--muted:#b7c2cf;--line:#26384d;--accent:#8bd0ff;--warm:#ffe39a;--green:#b6e3bd}
+    *{box-sizing:border-box}html{scroll-behavior:smooth}body{margin:0;background:var(--bg);color:var(--text);font-family:Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;line-height:1.65}a{color:var(--accent)}
+    .top{width:min(100% - 2rem,900px);margin:auto;padding:1.2rem 0;font-size:.92rem}.top a{color:var(--muted);text-decoration:none}
+    header,main{width:min(100% - 2rem,800px);margin:auto}header{padding:5.5rem 0 4.5rem;text-align:center}.eyebrow{color:var(--green);font-weight:800;font-size:.8rem;letter-spacing:.12em;text-transform:uppercase}h1{margin:.7rem 0 1rem;font-size:clamp(3.3rem,11vw,6.6rem);line-height:.95;letter-spacing:-.055em}h2{margin:0 0 .8rem;font-size:clamp(1.75rem,5vw,2.55rem);line-height:1.08}h3{margin:.15rem 0 .4rem;font-size:1.14rem}.lead{max-width:640px;margin:0 auto;color:var(--muted);font-size:clamp(1.1rem,2.8vw,1.35rem)}.bigline{max-width:650px;margin:1.8rem auto 0;color:var(--warm);font-size:clamp(1.3rem,3.4vw,1.8rem);font-weight:800;line-height:1.25}
+    .actions{display:flex;justify-content:center;gap:.75rem;flex-wrap:wrap;margin-top:2rem}.btn{display:inline-block;padding:.9rem 1.2rem;border-radius:999px;text-decoration:none;font-weight:800}.primary{background:var(--accent);color:#07111c}.quiet{border:1px solid var(--line);color:var(--muted)}
+    section{padding:3rem 0;border-top:1px solid var(--line)}p{margin:.75rem 0}.path{display:grid;gap:.85rem;margin-top:1.4rem}.step{display:grid;grid-template-columns:2.7rem 1fr;gap:1rem;padding:1.15rem;border:1px solid var(--line);border-radius:16px;background:var(--panel);text-decoration:none;color:var(--text)}.num{width:2.7rem;height:2.7rem;display:grid;place-items:center;border-radius:50%;background:rgba(139,208,255,.12);color:var(--accent);font-weight:900}.step span{color:var(--muted)}
+    .simple{display:grid;gap:.75rem;margin-top:1.2rem}.simple div{padding:1rem 1.1rem;border-left:3px solid var(--green);background:var(--panel);border-radius:0 12px 12px 0}.simple strong{display:block;margin-bottom:.25rem}.simple p{margin:0;color:var(--muted)}
+    details{margin-top:1rem;border:1px solid var(--line);border-radius:15px;background:var(--panel)}summary{cursor:pointer;padding:1.1rem 1.2rem;font-weight:800;color:var(--accent)}.deep{padding:0 1.2rem 1.2rem}.deep a{display:block;padding:.7rem 0;border-top:1px solid var(--line);text-decoration:none}.deep small{display:block;color:var(--muted);margin-top:.15rem}
+    footer{margin-top:2rem;padding:2.5rem 1rem 3rem;border-top:1px solid var(--line);text-align:center;color:var(--muted);font-size:.9rem}footer a{color:var(--muted);text-decoration:none}
+    @media(max-width:560px){header{padding:4rem 0 3.5rem}.step{grid-template-columns:2.45rem 1fr}.num{width:2.45rem;height:2.45rem}}
   </style>
 </head>
 <body>
-  <nav class="topbar"><a href="../index.html">← tmsteph home</a><div class="mini"><a href="start/index.html">Start Here</a><a href="audit/index.html">Audit</a><a href="evidence/index.html">Evidence</a><a href="launch/index.html">Launch</a><a href="current/index.html">Current</a></div></nav>
-  <header><div class="eyebrow">Thomas Stephens · Living doctrine · v0.17</div><h1>The Human Scale Doctrine</h1><p class="lead">A living framework for understanding modern life, living more humanly, and building a civilization around human flourishing.</p><div class="thesis">Humanity became powerful faster than it became wise.</div></header>
+  <nav class="top"><a href="../index.html">← tmsteph.com</a></nav>
+  <header>
+    <div class="eyebrow">A living project by Thomas Stephens</div>
+    <h1>Human Scale</h1>
+    <p class="lead">Modern life gives us amazing tools. It can also make it harder to sleep, move, connect, have time, and feel in control.</p>
+    <div class="bigline">Modern life is powerful. It should also feel human.</div>
+    <div class="actions"><a class="btn primary" href="start/index.html">Start here →</a><a class="btn quiet" href="audit/index.html">Skip to the 5-minute check</a></div>
+  </header>
+
   <main>
-    <section><h2>New here?</h2><p>You do not need to read seventeen chapters before this becomes useful.</p><div class="four"><a class="feature" href="start/index.html"><strong>Start Here →</strong><span>The whole project in about two minutes.</span></a><a class="feature" href="audit/index.html"><strong>Take the Human Scale Audit →</strong><span>A private five-minute check of whether your everyday environment supports human life.</span></a><a class="feature" href="launch/index.html"><strong>Break It. Test It. Build It. →</strong><span>The public launch: challenge a claim, run an experiment, or help build a real-world receipt.</span></a><a class="feature" href="evidence/index.html"><strong>Evidence Atlas — 17/17 chapters audited →</strong><span>What survived, what weakened, what is evidence, and what remains a value or proposal?</span></a></div></section>
-
-    <section><h2>The premise</h2><p>Human beings are biological organisms whose bodies and minds developed within nature, physical movement, sleep and light-dark rhythms, supportive social relationships, and dependence on living ecological systems. Modern industrial civilization changed many of those conditions at extraordinary speed.</p><div class="callout">The problem is not that humanity learned too much. The problem is that our power to redesign the world grew faster than our understanding of what kind of world human beings actually need.</div><p>The answer is not a romantic return to the past. <strong>Novelty is a reason to investigate, not a reason to condemn.</strong> Modern environments can be better than ancestral ones.</p></section>
-
-    <section><h2>What this is for</h2><div class="three"><div class="card"><h3>Diagnosis</h3><p>What is happening, and why?</p></div><div class="card"><h3>Field Guide</h3><p>What can people do now?</p></div><div class="card"><h3>Program</h3><p>What should we change together?</p></div></div><div class="four"><a class="feature" href="field-guide/index.html"><strong>Field Guide →</strong><span>Living more humanly now.</span></a><a class="feature" href="program/index.html"><strong>Program →</strong><span>Changing systems together.</span></a></div></section>
-
-    <section><h2>The doctrine changes when the evidence changes</h2><p>Every current chapter now has a public evidence audit. The audits are allowed to weaken the doctrine rather than merely decorate it with citations.</p><div class="four"><a class="feature" href="evidence/index.html"><strong>Evidence Atlas v0.6 →</strong><span>Seventeen chapter audits, explicit uncertainty, falsification conditions, and the cross-cutting research frontier.</span></a><a class="feature" href="current/index.html"><strong>Current State →</strong><span>The live project map: chapters, audits, Lab, San Diego, contribution paths, and what comes next.</span></a></div><div class="callout"><strong>Mismatch is a question to test, not an answer to assume.</strong> A doctrine that cannot lose an argument is not learning.</div></section>
-
-    <section><h2>Ten theses</h2><div class="theses">
-      <article class="thesis-card"><div class="number">1</div><div><h3>Human beings are biological organisms, not abstract economic units.</h3><p>Systems must begin with bodies, minds, relationships, development, and ecology.</p></div></article>
-      <article class="thesis-card"><div class="number">2</div><div><h3>Technological environments can change faster than biological adaptation.</h3><p>That makes mismatch possible, but novelty itself is neither proof of harm nor proof of progress.</p></div></article>
-      <article class="thesis-card"><div class="number">3</div><div><h3>Fossil energy accelerated environmental change.</h3><p>Human environments and institutions could transform at a speed and scale previously impossible.</p></div></article>
-      <article class="thesis-card"><div class="number">4</div><div><h3>Efficiency is not the same as flourishing.</h3><p>A system can produce more and move faster while making ordinary life worse.</p></div></article>
-      <article class="thesis-card"><div class="number">5</div><div><h3>Technology is a tool, not a destiny.</h3><p>We can decide which technologies deserve a place in human life and under what conditions.</p></div></article>
-      <article class="thesis-card"><div class="number">6</div><div><h3>Human-scale systems should be preferred when they work.</h3><p>Scale is a hypothesis to test, not a moral shortcut.</p></div></article>
-      <article class="thesis-card"><div class="number">7</div><div><h3>Advanced technology should become quieter.</h3><p>The best machines remove drudgery without consuming attention, identity, judgment, and purpose.</p></div></article>
-      <article class="thesis-card"><div class="number">8</div><div><h3>Open systems can protect human agency.</h3><p>Understanding, repair, interoperability, portability, and sharing matter where their benefits justify the tradeoffs.</p></div></article>
-      <article class="thesis-card"><div class="number">9</div><div><h3>Ecology is not an externality.</h3><p>Human civilization exists inside the living world, not outside it.</p></div></article>
-      <article class="thesis-card"><div class="number">10</div><div><h3>Recover what modernity discarded without discarding what humanity learned.</h3><p>We do not need to choose between the village and the computer. We can build both.</p></div></article>
-    </div></section>
-
-    <section><h2>The direction</h2><p><strong>Technology:</strong> open, repairable, interoperable, resilient, agency-expanding, and quiet enough to disappear when it is not needed.</p><p><strong>Energy:</strong> clean, reliable, affordable, resilient, with strong shared grids and meaningful local capacity where useful.</p><p><strong>Economy:</strong> productive and innovative while protecting practical freedom, broadening ownership, and making sure progress reaches ordinary life.</p><p><strong>Governance & rights:</strong> power at the smallest scale that can solve the problem well, bounded by equal dignity, pluralism, due process, practical exit, and capable institutions when larger scale is necessary.</p><p><strong>Health & care:</strong> modern medicine, prevention, primary and specialty care, public health, mental health, rehabilitation, disability support, caregiving, palliative care, safety, financial protection and usable information organized around the person.</p><p><strong>Land & ecology:</strong> safe green space, trees, soil, habitat, water, gardens and agriculture judged by function, ecology, access, maintenance and competing land needs.</p><p><strong>Food & place:</strong> safe and nourishing food, useful trade, enough housing, realistic mobility, public space, shade, beauty and daily environments that support human life.</p><p><strong>Education:</strong> serious knowledge combined with movement, belonging, practical competence, multiple pathways, increasing independence, and AI that scaffolds capability rather than replacing it.</p><p><strong>Community, family & meaning:</strong> durable relationships, safe care, pluralism, privacy, freedom of conscience, prayer or nonbelief, contemplation, art, music, philosophy, nature, and room to ask what life is for.</p><p><strong>AI & media:</strong> powerful tools and information systems judged by capability, truthfulness, privacy, skill, effective review, practical exit, freedom of expression, and distribution of gains.</p><div class="callout">The goal is not maximum technology, production, consumption, localism, schooling, medicine, spirituality, or central control. The goal is enough capability to support human life well.</div></section>
-
-    <section><h2>17 chapters</h2><p class="muted">Long chapters are optional depth. Every one now has a corresponding evidence audit.</p>
-      <a class="chapter" href="human-nature/index.html"><strong>1. Human Nature — The Environment We Were Built For →</strong><span>The mismatch lens, recurring human constraints, environmental design, and evidence discipline.</span></a>
-      <a class="chapter" href="land-life/index.html"><strong>2. Land & Life — Reconnecting Humans to the Living World →</strong><span>Ecological dependence, safe green space, trees, soil, gardens, stewardship and living infrastructure.</span></a>
-      <a class="chapter" href="community/revised/index.html"><strong>3. Community — The Human Need to Belong →</strong><span>Supportive connection, local opportunity, digital relationships, privacy, pluralism, and belonging without captivity.</span></a>
-      <a class="chapter" href="work-time/index.html"><strong>4. Work & Time — What Is a Human Life For? →</strong><span>Work, schedules, commuting, care, automation, agency, and human time.</span></a>
-      <a class="chapter" href="technology/index.html"><strong>5. Technology — Tools That Serve Life →</strong><span>Attention, repairability, AI, resilience, open systems, credible exit, and technological freedom.</span></a>
-      <a class="chapter" href="energy/index.html"><strong>6. Energy — Power Without Dependence →</strong><span>Reliable abundant energy, strong grids, distributed resilience, cleaner supply, efficiency, and stewardship.</span></a>
-      <a class="chapter" href="economics/index.html"><strong>7. Economics — What Is the Economy For? →</strong><span>Markets, security, ownership, competition, entrepreneurship, public goods, automation, and practical freedom.</span></a>
-      <a class="chapter" href="governance/index.html"><strong>8. Governance — Power Close Enough to Understand →</strong><span>Subsidiarity, rights, institutional capacity, legibility, coordination, and accountable power.</span></a>
-      <a class="chapter" href="food/index.html"><strong>9. Food — Nourishment, Culture & Living Systems →</strong><span>Safety, nutrition, food environments, agriculture, trade, resilience, labor, culture, and waste.</span></a>
-      <a class="chapter" href="architecture-place/index.html"><strong>10. Architecture & Place — Build for Human Life →</strong><span>Housing, access, mobility, heat, shade, public space, ecology, accessibility, beauty, and human time.</span></a>
-      <a class="chapter" href="education-childhood/index.html"><strong>11. Education & Childhood — Raising Capable Human Beings →</strong><span>Knowledge, movement, sleep, belonging, practical competence, independence, AI, and multiple paths into adulthood.</span></a>
-      <a class="chapter" href="health-care/index.html"><strong>12. Health & Care — Keeping People Well, Caring for People When They Aren’t →</strong><span>Modern medicine, primary health care, safety, coordination, rehabilitation, disability, financial protection and palliative care.</span></a>
-      <a class="chapter" href="family-care/index.html"><strong>13. Family & Care — The Relationships That Carry Life →</strong><span>Nurturing care, family pluralism, unpaid care, long-term care, caregiver support, safe continuity, and practical exit.</span></a>
-      <a class="chapter" href="attention-media/index.html"><strong>14. Attention & Media — What Gets to Enter the Mind →</strong><span>Persuasion, privacy, dark patterns, algorithms, advertising, youth safeguards, synthetic media, provenance, and expression.</span></a>
-      <a class="chapter" href="justice-rights/index.html"><strong>15. Justice & Rights — A Floor Beneath Localism →</strong><span>Equal dignity, rule of law, due process, pluralism, accessibility, institutional capacity, and appeal.</span></a>
-      <a class="chapter" href="spirituality-meaning/index.html"><strong>16. Spirituality & Meaning — What Is a Life For? →</strong><span>Religious freedom, nonbelief, metaphysical humility, ritual, institutional accountability, pluralism, and meaning.</span></a>
-      <a class="chapter" href="ai-automation/index.html"><strong>17. AI & Automation — Intelligence in Service of Human Agency →</strong><span>Risk-specific governance, automation, augmentation, skill, effective review, labor transformation, accountability, and broadly shared gains.</span></a>
+    <section>
+      <h2>What is Human Scale?</h2>
+      <p>It is a simple idea: <strong>keep what modern life does well, and make daily life fit people better.</strong></p>
+      <div class="simple">
+        <div><strong>Keep the good.</strong><p>Medicine, science, computers, energy, trade, cities, and useful machines.</p></div>
+        <div><strong>Bring back what people need.</strong><p>Time, movement, sleep, nature, close relationships, useful skills, and places to belong.</p></div>
+        <div><strong>Fix systems that get in the way.</strong><p>At home, at work, in neighborhoods, in technology, and in government.</p></div>
+      </div>
     </section>
 
-    <section><h2>One rule for the project</h2><p>Distinguish <strong>evidence</strong>, <strong>hypothesis</strong>, <strong>value judgment</strong>, and <strong>political proposal</strong>. Say <em>we do not know</em> when we do not know. State claims narrowly enough to be wrong. Seek counterexamples. Change the doctrine when reality contradicts it.</p><div class="four"><a class="feature" href="evidence/index.html"><strong>Evidence Atlas — 17/17 audited →</strong><span>See claim grades, chapter audits, corrections and falsification conditions.</span></a><a class="feature" href="launch/index.html"><strong>Public Launch — break it →</strong><span>Find a claim that fails, run an experiment, or help build something useful.</span></a></div></section>
+    <section>
+      <h2>A simple path</h2>
+      <p>You do not need to read a book. Start with these three steps.</p>
+      <div class="path">
+        <a class="step" href="start/index.html"><div class="num">1</div><div><h3>Understand the idea</h3><span>A short, plain-language introduction.</span></div></a>
+        <a class="step" href="audit/index.html"><div class="num">2</div><div><h3>Check your daily life</h3><span>See where life supports you and where it adds friction.</span></div></a>
+        <a class="step" href="try-one-thing/index.html"><div class="num">3</div><div><h3>Change one thing</h3><span>Pick one small change you can try this week.</span></div></a>
+      </div>
+    </section>
 
-    <section class="closing"><h2>The future</h2><p>We can keep the knowledge, science, computers, modern medicine, markets, schools, cities, specialized institutions, global exchange, and large infrastructure where they genuinely serve us.</p><p>And we can recover bodies, neighborhoods, gardens, useful competence, durable relationships, human time, living landscapes, understandable institutions, and freedom to ask what a life is for.</p><strong>The village and the computer can coexist.</strong><p class="version">Version 0.17 · 17 chapters · 17 evidence audits · a living doctrine expected to change as its ideas are challenged, tested, and refined.</p></section>
+    <section>
+      <h2>That is enough to begin.</h2>
+      <p>Human Scale is much bigger than these three steps. But the deeper work should be there when you want it — not in your way when you first arrive.</p>
+      <details>
+        <summary>Go deeper</summary>
+        <div class="deep">
+          <a href="field-guide/index.html"><strong>Field Guide</strong><small>Practical ideas for everyday life.</small></a>
+          <a href="program/index.html"><strong>Program</strong><small>Ideas for what we can change together.</small></a>
+          <a href="evidence/index.html"><strong>Evidence Atlas</strong><small>Research, uncertainty, and what has changed our minds.</small></a>
+          <a href="manifesto/index.html"><strong>One-page manifesto</strong><small>The main argument in one short read.</small></a>
+          <a href="current/index.html"><strong>Full project</strong><small>17 chapters, audits, experiments, local work, and ways to contribute.</small></a>
+        </div>
+      </details>
+    </section>
   </main>
-  <footer><a href="start/index.html">Start Here</a> · <a href="launch/index.html">Launch</a> · <a href="current/index.html">Current</a> · <a href="audit/index.html">Audit</a> · <a href="feed.xml">RSS</a> · <a href="../index.html">tmsteph.com</a></footer>
+
+  <footer>Human Scale · v0.18 · <a href="feed.xml">RSS</a> · <a href="../index.html">tmsteph.com</a></footer>
 </body>
 </html>

--- a/human-scale/start/index.html
+++ b/human-scale/start/index.html
@@ -4,42 +4,77 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Start Here — Human Scale</title>
-  <meta name="description" content="A two-minute introduction to Human Scale: a living philosophy for building modern civilization around human flourishing." />
+  <meta name="description" content="A short, plain-language introduction to Human Scale." />
+  <meta name="theme-color" content="#08111d" />
   <link rel="canonical" href="https://tmsteph.com/human-scale/start/" />
   <meta property="og:title" content="Human Scale — Start Here" />
-  <meta property="og:description" content="Keep the science. Keep the computers. Recover the human world." />
+  <meta property="og:description" content="Keep the good parts of modern life. Make daily life fit people better." />
   <meta property="og:url" content="https://tmsteph.com/human-scale/start/" />
   <meta property="og:type" content="article" />
   <meta name="twitter:card" content="summary" />
-  <meta name="theme-color" content="#07111f" />
   <link rel="icon" href="../../favicon.ico" type="image/x-icon" />
   <script defer src="/_vercel/analytics/script.js"></script>
   <style>
-    :root{color-scheme:dark;--bg:#07111f;--panel:#0c192a;--text:#edf3fa;--muted:#aab9ca;--line:#243850;--sky:#7bcaff;--green:#a9ddb0;--sun:#ffe18a}
-    *{box-sizing:border-box}body{margin:0;font-family:Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;background:radial-gradient(circle at 12% 0%,rgba(123,202,255,.12),transparent 34rem),var(--bg);color:var(--text);line-height:1.72}a{color:var(--sky)}.top{width:min(100% - 2rem,900px);margin:0 auto;padding:1.2rem 0;color:var(--muted)}.top a{color:var(--muted);text-decoration:none}header,main{width:min(100% - 2rem,820px);margin:0 auto}header{padding:5rem 0 3.5rem;text-align:center}.eyebrow{color:var(--green);font-size:.78rem;font-weight:850;letter-spacing:.15em;text-transform:uppercase}h1{margin:.7rem 0 1rem;font-size:clamp(3rem,9vw,5.8rem);line-height:.96;letter-spacing:-.055em}h2{margin:0 0 .8rem;font-size:clamp(1.8rem,5vw,2.7rem);line-height:1.08}.lead{margin:0 auto;color:var(--muted);font-size:clamp(1.1rem,2.5vw,1.34rem)}section{padding:2.8rem 0;border-top:1px solid var(--line)}.callout{padding:1.35rem 1.45rem;border:1px solid rgba(255,225,138,.28);border-radius:18px;background:rgba(255,225,138,.045);color:#fff4cf;font-size:1.2rem;font-weight:750}.grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:1rem;margin-top:1.2rem}.card{display:block;padding:1.25rem;border:1px solid var(--line);border-radius:16px;background:var(--panel);color:var(--text);text-decoration:none}.card strong{display:block;color:var(--sky);font-size:1.08rem}.card span{display:block;margin-top:.45rem;color:var(--muted)}.line{font-size:1.2rem}.closing{text-align:center}.closing strong{display:block;margin:1.5rem auto;color:var(--sun);font-size:clamp(1.6rem,5vw,2.35rem);line-height:1.15}footer{margin-top:3rem;padding:2.5rem 1rem 3rem;border-top:1px solid var(--line);text-align:center;color:var(--muted)}footer a{text-decoration:none}
+    :root{color-scheme:dark;--bg:#08111d;--panel:#101c2b;--text:#f2f5f8;--muted:#b7c2cf;--line:#26384d;--accent:#8bd0ff;--warm:#ffe39a;--green:#b6e3bd}
+    *{box-sizing:border-box}body{margin:0;background:var(--bg);color:var(--text);font-family:Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;line-height:1.65}a{color:var(--accent)}
+    .top,header,main{width:min(100% - 2rem,760px);margin:auto}.top{padding:1.2rem 0;color:var(--muted);font-size:.92rem}.top a{color:var(--muted);text-decoration:none}header{padding:4.5rem 0 3.5rem;text-align:center}.eyebrow{color:var(--green);font-size:.82rem;font-weight:800;letter-spacing:.1em;text-transform:uppercase}h1{margin:.65rem 0 1rem;font-size:clamp(2.8rem,9vw,5rem);line-height:.98;letter-spacing:-.045em}h2{font-size:clamp(1.65rem,5vw,2.35rem);line-height:1.1;margin:0 0 .8rem}h3{margin:.1rem 0 .35rem;font-size:1.13rem}.lead{max-width:620px;margin:auto;color:var(--muted);font-size:1.18rem}
+    section{padding:2.7rem 0;border-top:1px solid var(--line)}p{margin:.8rem 0}.plain{font-size:1.15rem}.callout{margin-top:1.3rem;padding:1.2rem 1.3rem;border-radius:14px;background:var(--panel);border-left:4px solid var(--warm);color:#fff2c7;font-weight:750}.cards{display:grid;gap:.8rem;margin-top:1.25rem}.card{padding:1.05rem 1.15rem;border:1px solid var(--line);border-radius:14px;background:var(--panel)}.card p{margin:0;color:var(--muted)}
+    .questions{display:grid;gap:.75rem;margin-top:1.2rem}.q{padding:.9rem 1rem;border-left:3px solid var(--accent);background:var(--panel);border-radius:0 12px 12px 0;font-weight:700}
+    .next{padding:3rem 0;text-align:center}.btn{display:inline-block;margin-top:1rem;padding:.95rem 1.25rem;border-radius:999px;background:var(--accent);color:#07111c;text-decoration:none;font-weight:900}.small{margin-top:1rem;color:var(--muted);font-size:.9rem}.small a{color:var(--muted)}
+    footer{margin-top:1rem;padding:2.5rem 1rem 3rem;border-top:1px solid var(--line);text-align:center;color:var(--muted);font-size:.9rem}footer a{color:var(--muted);text-decoration:none}
   </style>
 </head>
 <body>
-  <nav class="top"><a href="../index.html">← Human Scale Doctrine</a></nav>
-  <header><div class="eyebrow">Two-minute introduction</div><h1>Human Scale</h1><p class="lead">A living attempt to answer one question: <strong>how do we keep the extraordinary capabilities of modern civilization while rebuilding everyday life around actual human beings?</strong></p></header>
+  <nav class="top"><a href="../index.html">← Human Scale</a></nav>
+  <header>
+    <div class="eyebrow">Step 1 of 3 · Understand the idea</div>
+    <h1>Modern life should work for people.</h1>
+    <p class="lead">Human Scale is about keeping the best parts of modern life while making everyday life healthier, calmer, more connected, and easier to understand.</p>
+  </header>
+
   <main>
-    <section><div class="callout">Humanity became powerful faster than it became wise.</div><p>Industrial energy, machines, markets, institutions, cars, networks, and computers gave us capabilities previous generations could barely imagine. They also allowed us to redesign the human environment faster than we understood what human bodies, minds, relationships, and communities need.</p><p>The answer is not to return to the past. The answer is to become more deliberate about what progress is for.</p></section>
+    <section>
+      <h2>We gained a lot.</h2>
+      <p class="plain">Modern life gave us medicine, electricity, machines, fast travel, computers, clean water, global knowledge, and many kinds of freedom.</p>
+      <p><strong>Human Scale is not about giving those things up.</strong></p>
+    </section>
 
-    <section><h2>The basic idea</h2><p class="line"><strong>Keep the medicine. Keep the science. Keep the computers. Keep abundant energy, trade, cities, specialization, and large systems where they work.</strong></p><p>And recover movement, sleep, nature, time, family, friendship, useful competence, local participation, repairability, public space, living land, understandable institutions, and the ability to leave systems that stop serving us.</p><p>Human Scale does not mean small is always better. It means <strong>scale has to justify itself.</strong></p></section>
+    <section>
+      <h2>But daily life can still feel wrong.</h2>
+      <p>Many people spend too much time sitting, driving, scrolling, working, waiting, or dealing with systems they do not understand.</p>
+      <p>It can be hard to get enough sleep, see friends, spend time outside, cook, move your body, or feel like your time is your own.</p>
+      <div class="callout">A modern life can be advanced and still be hard on people.</div>
+    </section>
 
-    <section><h2>Four layers</h2><div class="grid">
-      <a class="card" href="../index.html"><strong>Doctrine</strong><span>What kind of civilization should we build?</span></a>
-      <a class="card" href="../field-guide/index.html"><strong>Field Guide</strong><span>How can I live more humanly inside the world that exists?</span></a>
-      <a class="card" href="../program/index.html"><strong>Program</strong><span>What should communities, workplaces, cities, and governments change together?</span></a>
-      <a class="card" href="../evidence/index.html"><strong>Evidence Atlas</strong><span>What do we actually know, what do we suspect, and what are we choosing?</span></a>
-    </div></section>
+    <section>
+      <h2>The idea is simple.</h2>
+      <div class="cards">
+        <div class="card"><h3>Keep what helps.</h3><p>Science, medicine, technology, energy, trade, and large systems when they work well.</p></div>
+        <div class="card"><h3>Make room for human needs.</h3><p>Sleep, movement, nature, close relationships, time, meaning, useful skills, and places to belong.</p></div>
+        <div class="card"><h3>Change bad defaults.</h3><p>If a home, job, street, app, or public system keeps making life harder, ask how it could work better.</p></div>
+      </div>
+    </section>
 
-    <section><h2>Try it instead of agreeing with it</h2><p>You do not need to adopt a worldview to test whether it notices something real. Take the five-minute audit, find the largest recurring friction in your environment, and ask whether it is personal, household-level, local, institutional, or structural.</p><div class="grid"><a class="card" href="../audit/index.html"><strong>Take the Human Scale Audit →</strong><span>No account. No server-side answers. A private reflection on body, nature, time, community, place, security, and agency.</span></a><a class="card" href="../manifesto/index.html"><strong>Read the one-page manifesto →</strong><span>The whole argument in a few minutes.</span></a></div></section>
+    <section>
+      <h2>Human Scale asks a few basic questions.</h2>
+      <div class="questions">
+        <div class="q">Does this help people live healthy lives?</div>
+        <div class="q">Does it give people time and real choices?</div>
+        <div class="q">Does it help people connect with other people and the living world?</div>
+        <div class="q">Can normal people understand it, use it, and leave it if they need to?</div>
+        <div class="q">Is the size of the system helping, or just making it harder to control?</div>
+      </div>
+      <p>There is no rule that small is always good or new is always bad. <strong>We test what works.</strong></p>
+    </section>
 
-    <section><h2>The intellectual rule</h2><p>Human Scale distinguishes <strong>evidence, hypothesis, value judgment, and political proposal</strong>. The project should be allowed to have convictions. It should not be allowed to hide uncertainty.</p><p>If reality contradicts the doctrine, the doctrine should change.</p></section>
-
-    <section class="closing"><h2>The direction</h2><p>Human Scale is neither anti-modern nor acceleration-at-any-cost.</p><strong>The village and the computer can coexist.</strong><p>The work is figuring out how.</p><div class="grid"><a class="card" href="../share/index.html"><strong>Help spread or challenge it →</strong><span>Share links, discussion prompts, launch notes, and ways to contribute without spamming people.</span></a></div></section>
+    <section class="next">
+      <h2>Now look at your own life.</h2>
+      <p>The next step is a short check. It is not a test and there is no perfect score.</p>
+      <a class="btn" href="../audit/index.html">Step 2: Check your daily life →</a>
+      <p class="small">Want the longer version instead? <a href="../manifesto/index.html">Read the one-page manifesto</a>.</p>
+    </section>
   </main>
-  <footer><a href="../index.html">Doctrine</a> · <a href="../audit/index.html">Audit</a> · <a href="../share/index.html">Share</a> · <a href="../../index.html">tmsteph.com</a></footer>
+
+  <footer>Human Scale · <a href="../index.html">Home</a> · <a href="../../index.html">tmsteph.com</a></footer>
 </body>
 </html>

--- a/human-scale/try-one-thing/index.html
+++ b/human-scale/try-one-thing/index.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Change One Thing — Human Scale</title>
+  <meta name="description" content="Pick one small Human Scale change to try this week." />
+  <meta name="theme-color" content="#08111d" />
+  <link rel="canonical" href="https://tmsteph.com/human-scale/try-one-thing/" />
+  <meta property="og:title" content="Human Scale — Change One Thing" />
+  <meta property="og:description" content="Do not fix your whole life. Pick one useful change and try it." />
+  <meta property="og:url" content="https://tmsteph.com/human-scale/try-one-thing/" />
+  <meta property="og:type" content="article" />
+  <meta name="twitter:card" content="summary" />
+  <link rel="icon" href="../../favicon.ico" type="image/x-icon" />
+  <script defer src="/_vercel/analytics/script.js"></script>
+  <style>
+    :root{color-scheme:dark;--bg:#08111d;--panel:#101c2b;--text:#f2f5f8;--muted:#b7c2cf;--line:#26384d;--accent:#8bd0ff;--warm:#ffe39a;--green:#b6e3bd}
+    *{box-sizing:border-box}body{margin:0;background:var(--bg);color:var(--text);font-family:Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;line-height:1.65}a{color:var(--accent)}.top,header,main{width:min(100% - 2rem,760px);margin:auto}.top{padding:1.2rem 0;color:var(--muted);font-size:.92rem}.top a{color:var(--muted);text-decoration:none}header{padding:4.2rem 0 3.4rem;text-align:center}.eyebrow{color:var(--green);font-size:.82rem;font-weight:800;letter-spacing:.1em;text-transform:uppercase}h1{margin:.65rem 0 1rem;font-size:clamp(2.8rem,9vw,5rem);line-height:.98;letter-spacing:-.045em}h2{font-size:clamp(1.65rem,5vw,2.3rem);line-height:1.1;margin:0 0 .8rem}.lead{max-width:620px;margin:auto;color:var(--muted);font-size:1.16rem}section{padding:2.7rem 0;border-top:1px solid var(--line)}p{margin:.8rem 0}.rule{padding:1.1rem 1.2rem;border-radius:14px;background:var(--panel);border-left:4px solid var(--warm);color:#fff1c2;font-weight:800}
+    details{margin:.7rem 0;border:1px solid var(--line);border-radius:13px;background:var(--panel)}summary{cursor:pointer;padding:1rem 1.1rem;font-weight:850;color:var(--accent)}.inside{padding:0 1.1rem 1.1rem;color:var(--muted)}.inside strong{color:var(--text)}.inside ul{margin:.6rem 0 0;padding-left:1.25rem}.inside li{margin:.45rem 0}
+    .civic{display:grid;gap:.65rem;margin-top:1.1rem}.civic div{padding:.9rem 1rem;background:var(--panel);border-radius:12px}.civic strong{color:var(--green)}.links{display:grid;gap:.7rem;margin-top:1.2rem}.link{display:block;padding:1rem 1.1rem;border:1px solid var(--line);border-radius:13px;background:var(--panel);color:var(--text);text-decoration:none}.link strong{color:var(--accent)}.link span{display:block;color:var(--muted);margin-top:.25rem}.finish{text-align:center}.finish strong{display:block;margin:1.3rem auto;color:var(--warm);font-size:1.4rem}
+    footer{padding:2.5rem 1rem 3rem;border-top:1px solid var(--line);text-align:center;color:var(--muted);font-size:.9rem}footer a{color:var(--muted);text-decoration:none}
+  </style>
+</head>
+<body>
+  <nav class="top"><a href="../audit/index.html">← Step 2</a></nav>
+  <header>
+    <div class="eyebrow">Step 3 of 3 · Change one thing</div>
+    <h1>Make one part of life easier.</h1>
+    <p class="lead">Pick the area that felt hardest in your check. Then choose one small change you can try this week.</p>
+  </header>
+
+  <main>
+    <section>
+      <div class="rule">Do not try to fix everything at once.</div>
+      <p>Open the area you want to work on. Pick one idea. Change it if you need to. The goal is to learn what helps.</p>
+
+      <details><summary>Body</summary><div class="inside"><ul><li>Take a 10-minute walk.</li><li>Put your phone away 30 minutes before bed.</li><li>Make one normal task more active: stairs, carrying, stretching, or playing.</li></ul></div></details>
+      <details><summary>Nature</summary><div class="inside"><ul><li>Spend 10 minutes outside with no screen.</li><li>Eat one meal outside.</li><li>Care for a plant, garden, pet, or nearby patch of land.</li></ul></div></details>
+      <details><summary>People</summary><div class="inside"><ul><li>Call or text one person you want to stay close to.</li><li>Spend time in a library, park, plaza, faith space, or other place where people can simply be.</li><li>Offer one small piece of help to someone nearby.</li></ul></div></details>
+      <details><summary>Time</summary><div class="inside"><ul><li>Protect 30 minutes this week for something that matters to you.</li><li>Remove one task or notification that does not need your attention.</li><li>Plan one evening with a clear stopping time for work and screens.</li></ul></div></details>
+      <details><summary>Agency</summary><div class="inside"><ul><li>Turn off one app notification that keeps pulling you back.</li><li>Learn how one important system in your life actually works.</li><li>Export or back up one piece of data you do not want trapped in a platform.</li></ul></div></details>
+      <details><summary>Place</summary><div class="inside"><ul><li>Walk one common route and notice crossings, shade, noise, seating, and safety.</li><li>Find one useful place close to home that you have not been using.</li><li>Move one daily need closer if you can.</li></ul></div></details>
+      <details><summary>Security</summary><div class="inside"><ul><li>Learn the exact cost of one monthly bill.</li><li>Put a small amount into an emergency buffer if you can.</li><li>Practice one skill that can save money, earn money, repair something, or make you less dependent.</li></ul></div></details>
+      <details><summary>Meaning</summary><div class="inside"><ul><li>Make music, write, pray, meditate, read, build, or create for 15 minutes.</li><li>Spend a little time on something you would still care about if nobody could like or share it.</li><li>Ask yourself: what do I want more of in my real life?</li></ul></div></details>
+    </section>
+
+    <section>
+      <h2>What if the problem is bigger than you?</h2>
+      <p>If many people around you have the same problem, it may be a system problem. You do not have to solve it alone.</p>
+      <div class="civic">
+        <div><strong>1. Name it.</strong> What keeps going wrong?</div>
+        <div><strong>2. Measure it.</strong> Take notes, count time, take photos, or collect examples.</div>
+        <div><strong>3. Find the lever.</strong> Who can actually change it?</div>
+        <div><strong>4. Try something small.</strong> Test one fix and see what happens.</div>
+      </div>
+    </section>
+
+    <section class="finish">
+      <h2>You finished the beginner path.</h2>
+      <strong>Notice. Try. Learn. Then go deeper if it helps.</strong>
+      <div class="links">
+        <a class="link" href="../field-guide/index.html"><strong>Field Guide →</strong><span>More practical ideas for daily life.</span></a>
+        <a class="link" href="../program/index.html"><strong>Program →</strong><span>Ideas for changing systems together.</span></a>
+        <a class="link" href="../evidence/index.html"><strong>Evidence →</strong><span>See the research and the places we are still unsure.</span></a>
+      </div>
+    </section>
+  </main>
+
+  <footer>Human Scale · <a href="../index.html">Start over</a> · <a href="../../index.html">tmsteph.com</a></footer>
+</body>
+</html>


### PR DESCRIPTION
## What changed
- Rebuilt the Human Scale front door for a first-time visitor.
- Lowered the reading level and removed most advanced choices from the first screen.
- Created a single three-step path: **Understand the idea → Check your daily life → Change one thing**.
- Rewrote the Start page in plain language.
- Simplified the Audit into a reflection map instead of a 0–100 score.
- Added a new `try-one-thing` page with small practical actions and a simple bridge from personal friction to civic action.
- Moved advanced material such as the Field Guide, Program, Evidence Atlas, manifesto, and full project map behind a quiet **Go deeper** control.
- Corrected the public Human Scale version label to v0.18.

## New-user design rule
A new visitor should not need to understand the project structure before the project becomes useful.

The beginner experience now asks for one decision at a time:
1. Learn the idea.
2. Look at your own life.
3. Try one change.

## Audit change
The previous overall 0–100 score has been removed from the beginner experience. The project’s own calibration audit already treats the total score as an unvalidated hypothesis. Results now show relative areas of support/friction instead of implying false precision.

## Validation
- One batched Git commit, avoiding the previous Vercel build-rate problem.
- Branch is 1 commit ahead / 0 behind `main`.
- Exactly four intended paths changed: Human Scale root, Start, Audit, and new `try-one-thing` page.
- Exact branch commit `adf6bd0c3c64fdb8f0b383f0eccd06d3095afbac` built successfully on Vercel and is `READY`.
- Preview front door returns HTTP 200 with the simplified path.